### PR TITLE
Fix `make` more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ setup:
 publish:
 	maturin publish
 
+test: test-python test-rust
+
 test-python:
 	pytest -vs tests/python
 	rm -rf tests/work/*

--- a/README.md
+++ b/README.md
@@ -91,15 +91,11 @@ make test
 ```
 You can choose to run just the Python or Rust tests by calling `make test-python` or `make test-rust` respectively.
 
-You can skip S3 related tests by exporting DOLMA_TESTS_SKIP_AWS=True
+You can skip S3 related tests by exporting `DOLMA_TESTS_SKIP_AWS=True`
 
 ```shell
 DOLMA_TESTS_SKIP_AWS=True make test
-DOLMA_TESTS_SKIP_AWS=True make test-python
-DOLMA_TESTS_SKIP_AWS=True make test-rust
 ```
-
-
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,17 @@ To run tests, use the following command.
 ```shell
 make test
 ```
-
 You can choose to run just the Python or Rust tests by calling `make test-python` or `make test-rust` respectively.
+
+You can skip S3 related tests by exporting DOLMA_TESTS_SKIP_AWS=True
+
+```shell
+DOLMA_TESTS_SKIP_AWS=True make test
+DOLMA_TESTS_SKIP_AWS=True make test-python
+DOLMA_TESTS_SKIP_AWS=True make test-rust
+```
+
+
 
 ## Contributing
 

--- a/src/s3_util.rs
+++ b/src/s3_util.rs
@@ -272,9 +272,8 @@ mod test {
 
     #[test]
     fn test_object_size() -> Result<(), io::Error> {
-        if std::env::var("DOLMA_TESTS_SKIP_AWS")
-            .ok()
-            .map_or(false, |v| v.to_lowercase() == "true")
+        if std::env::var_os("DOLMA_TESTS_SKIP_AWS")
+            .is_some_and(|var| var.eq_ignore_ascii_case("true"))
         {
             println!("Skipping test_download_file because DOLMA_TESTS_SKIP_AWS=True");
             return Ok(());
@@ -295,9 +294,8 @@ mod test {
 
     #[test]
     fn test_download_file() -> Result<(), io::Error> {
-        if std::env::var("DOLMA_TESTS_SKIP_AWS")
-            .ok()
-            .map_or(false, |v| v.to_lowercase() == "true")
+        if std::env::var_os("DOLMA_TESTS_SKIP_AWS")
+            .is_some_and(|var| var.eq_ignore_ascii_case("true"))
         {
             println!("Skipping test_download_file because DOLMA_TESTS_SKIP_AWS=True");
             return Ok(());
@@ -325,9 +323,8 @@ mod test {
 
     #[test]
     fn test_find_objects_matching_patterns() -> Result<(), io::Error> {
-        if std::env::var("DOLMA_TESTS_SKIP_AWS")
-            .ok()
-            .map_or(false, |v| v.to_lowercase() == "true")
+        if std::env::var_os("DOLMA_TESTS_SKIP_AWS")
+            .is_some_and(|var| var.eq_ignore_ascii_case("true"))
         {
             println!("Skipping test_download_file because DOLMA_TESTS_SKIP_AWS=True");
             return Ok(());

--- a/src/s3_util.rs
+++ b/src/s3_util.rs
@@ -272,7 +272,10 @@ mod test {
 
     #[test]
     fn test_object_size() -> Result<(), io::Error> {
-        if std::env::var("DOLMA_TESTS_SKIP_AWS").ok().map_or(false, |v| v.to_lowercase() == "true") {
+        if std::env::var("DOLMA_TESTS_SKIP_AWS")
+            .ok()
+            .map_or(false, |v| v.to_lowercase() == "true")
+        {
             println!("Skipping test_download_file because DOLMA_TESTS_SKIP_AWS=True");
             return Ok(());
         }
@@ -292,7 +295,10 @@ mod test {
 
     #[test]
     fn test_download_file() -> Result<(), io::Error> {
-        if std::env::var("DOLMA_TESTS_SKIP_AWS").ok().map_or(false, |v| v.to_lowercase() == "true") {
+        if std::env::var("DOLMA_TESTS_SKIP_AWS")
+            .ok()
+            .map_or(false, |v| v.to_lowercase() == "true")
+        {
             println!("Skipping test_download_file because DOLMA_TESTS_SKIP_AWS=True");
             return Ok(());
         }
@@ -319,7 +325,10 @@ mod test {
 
     #[test]
     fn test_find_objects_matching_patterns() -> Result<(), io::Error> {
-        if std::env::var("DOLMA_TESTS_SKIP_AWS").ok().map_or(false, |v| v.to_lowercase() == "true") {
+        if std::env::var("DOLMA_TESTS_SKIP_AWS")
+            .ok()
+            .map_or(false, |v| v.to_lowercase() == "true")
+        {
             println!("Skipping test_download_file because DOLMA_TESTS_SKIP_AWS=True");
             return Ok(());
         }

--- a/src/s3_util.rs
+++ b/src/s3_util.rs
@@ -272,6 +272,10 @@ mod test {
 
     #[test]
     fn test_object_size() -> Result<(), io::Error> {
+        if std::env::var("DOLMA_TESTS_SKIP_AWS").ok().map_or(false, |v| v.to_lowercase() == "true") {
+            println!("Skipping test_download_file because DOLMA_TESTS_SKIP_AWS=True");
+            return Ok(());
+        }
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -288,6 +292,10 @@ mod test {
 
     #[test]
     fn test_download_file() -> Result<(), io::Error> {
+        if std::env::var("DOLMA_TESTS_SKIP_AWS").ok().map_or(false, |v| v.to_lowercase() == "true") {
+            println!("Skipping test_download_file because DOLMA_TESTS_SKIP_AWS=True");
+            return Ok(());
+        }
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -311,6 +319,10 @@ mod test {
 
     #[test]
     fn test_find_objects_matching_patterns() -> Result<(), io::Error> {
+        if std::env::var("DOLMA_TESTS_SKIP_AWS").ok().map_or(false, |v| v.to_lowercase() == "true") {
+            println!("Skipping test_download_file because DOLMA_TESTS_SKIP_AWS=True");
+            return Ok(());
+        }
         let s3_client = new_client(None)?;
 
         let patterns =


### PR DESCRIPTION
Makefile still doesn't work in someways.
This PR plugs the gaps.

To be honest I am not happy with how I am skipping the rust test since they return as successful instead of ignored.
One difficulty is to maintain the tests by default instead of enabling it. 

I thought of a solution that is the cleanest :  
Prepend all s3 related rust tests with s3 and attach `#[ignore]`.
They would be re-enabled on demand as such : `cargo test s3`
https://doc.rust-lang.org/book/ch11-02-running-tests.html#filtering-to-run-multiple-tests

However, this might make life more difficult for the current main developers who would have to go through more hoops at the expense of potential outside contributors.
The default settings should be helpful to the default developers.

At this point, my goal is to just make rust tests run and succeed.

IMO we can implement this PR as a stop gap and then move on to a more permanent solution when we can.