### PR TITLE
Bloom refactor

### DIFF
--- a/src/bloom_filter/bloom_math.rs
+++ b/src/bloom_filter/bloom_math.rs
@@ -1,17 +1,23 @@
 use super::BloomFilter;
 
 impl BloomFilter {
-    // n: number of items in filter. p: false positive rate
-    // m: number of bits in filter. k: number of hashers
+    // Technically, we need 3 out of 4 to calculate the other.
+    // But we often want many of these to be either minimum itself or to allow other values to be minima.
+    // So we often only need 2 out of 4 ot calculate other two values.
+    // n: number of items (expected) in filter.
+    // p: (target) false positive rate
+    // m: number of bits in filter.
+    // k: number of hashers
     // n = ceil(m / (-k / log(1 - exp(log(p) / k))))
     // p = pow(1 - exp(-k / (m / n)), k)
     // m = ceil((n * log(p)) / log(1 / pow(2, log(2))));
     // k = round((m / n) * log(2));
 
     pub fn optimal_number_of_hashers(size_in_bytes: usize, expected_elements: usize) -> usize {
-        let expected_elements = expected_elements as f64;
-        let size_in_bits = (size_in_bytes * 8) as f64;
-        let k = (size_in_bits / expected_elements) * (2.0f64.ln());
+        use std::f64::consts::LN_2;
+        let n = expected_elements as f64;
+        let m = (size_in_bytes * 8) as f64;
+        let k = (m / n) * (LN_2);
         k.ceil() as usize
     }
 
@@ -20,9 +26,9 @@ impl BloomFilter {
         expected_elements: usize,
         num_hashers: usize,
     ) -> f64 {
-        let k = num_hashers as f64;
-        let m = (size_in_bytes * 8) as f64;
         let n = expected_elements as f64;
+        let m = (size_in_bytes * 8) as f64;
+        let k = num_hashers as f64;
         (1.0 - (1.0 - (1.0 / m)).powf(k * n)).powf(k)
     }
 
@@ -30,8 +36,10 @@ impl BloomFilter {
         expected_elements: usize,
         desired_false_positive_rate: f64,
     ) -> usize {
-        let mut size_in_bytes = 1024 * 1024;
-        while size_in_bytes < usize::MAX / 2
+        let min_size: usize = 1 << 20; // 1MiB
+        let max_size: usize = usize::MAX / 2; // 9E18 bytes 8exbi-bytes
+        let mut size_in_bytes = min_size;
+        while size_in_bytes < max_size
             && Self::prob_of_false_positive(
                 size_in_bytes,
                 expected_elements,

--- a/src/bloom_filter/bloom_math.rs
+++ b/src/bloom_filter/bloom_math.rs
@@ -1,0 +1,45 @@
+use super::BloomFilter;
+
+impl BloomFilter {
+    // n: number of items in filter. p: false positive rate
+    // m: number of bits in filter. k: number of hashers
+    // n = ceil(m / (-k / log(1 - exp(log(p) / k))))
+    // p = pow(1 - exp(-k / (m / n)), k)
+    // m = ceil((n * log(p)) / log(1 / pow(2, log(2))));
+    // k = round((m / n) * log(2));
+
+    pub fn optimal_number_of_hashers(size_in_bytes: usize, expected_elements: usize) -> usize {
+        let expected_elements = expected_elements as f64;
+        let size_in_bits = (size_in_bytes * 8) as f64;
+        let k = (size_in_bits / expected_elements) * (2.0f64.ln());
+        k.ceil() as usize
+    }
+
+    pub fn prob_of_false_positive(
+        size_in_bytes: usize,
+        expected_elements: usize,
+        num_hashers: usize,
+    ) -> f64 {
+        let k = num_hashers as f64;
+        let m = (size_in_bytes * 8) as f64;
+        let n = expected_elements as f64;
+        (1.0 - (1.0 - (1.0 / m)).powf(k * n)).powf(k)
+    }
+
+    pub fn suggest_size_in_bytes(
+        expected_elements: usize,
+        desired_false_positive_rate: f64,
+    ) -> usize {
+        let mut size_in_bytes = 1024 * 1024;
+        while size_in_bytes < usize::MAX / 2
+            && Self::prob_of_false_positive(
+                size_in_bytes,
+                expected_elements,
+                Self::optimal_number_of_hashers(size_in_bytes, expected_elements),
+            ) > desired_false_positive_rate
+        {
+            size_in_bytes *= 2;
+        }
+        size_in_bytes
+    }
+}

--- a/src/bloom_filter/bloom_test.rs
+++ b/src/bloom_filter/bloom_test.rs
@@ -12,9 +12,10 @@ mod tests {
     fn simplified_suggest_size(expected_elements: usize, target_fp_rate: f64) -> usize {
         // m = ceil((n * log(p)) / log(1 / pow(2, log(2))));
         use std::f64::consts::LN_2;
-        (expected_elements as f64 * target_fp_rate.ln() / (-LN_2 * LN_2))
+        let theoretical_optimum = (expected_elements as f64 * target_fp_rate.ln() / (-LN_2 * LN_2))
             .ceil()
-            .div_euclid(8.0) as usize
+            .div_euclid(8.0) as usize;
+        theoretical_optimum.next_power_of_two()
     }
 
     #[test]
@@ -52,10 +53,10 @@ mod tests {
         // instead of exact theoretical optimum
         let expected_elements = 1_000_000;
         let target_fp_rate = 0.0001 as f64;
-        
-        let theoretical_optimum = simplified_suggest_size(expected_elements, target_fp_rate);
+
+        let simplified_suggest_size = simplified_suggest_size(expected_elements, target_fp_rate);
         let suggested_size = BloomFilter::suggest_size_in_bytes(expected_elements, target_fp_rate);
         assert_eq!(suggested_size, 4_194_304);
-        assert_eq!(suggested_size, theoretical_optimum.next_power_of_two())
+        assert_eq!(suggested_size, simplified_suggest_size)
     }
 }

--- a/src/bloom_filter/bloom_test.rs
+++ b/src/bloom_filter/bloom_test.rs
@@ -40,16 +40,15 @@ mod tests {
 
     #[test]
     fn bloom_suggest_size() {
+        use std::f64::consts::LN_2;
         // it's hard to derive this exactly since the algorithm is doing closest power of 2
         // instead of exact theoretical optimum
         let expected_elements = 1_000_000;
-        let desired_false_positive_rate = 0.0001 as f64;
-        let theoretical_optimum = ((expected_elements as f64 * desired_false_positive_rate.ln())
-            / f64::ln(1.0 / 2.0f64.powf(2.0f64.ln())))
-        .ceil()
-        .div_euclid(8f64) as usize;
-        let suggested_size =
-            BloomFilter::suggest_size_in_bytes(expected_elements, desired_false_positive_rate);
+        let target_fp_rate = 0.0001 as f64;
+        let theoretical_optimum = (expected_elements as f64 * target_fp_rate.ln() / (-LN_2 * LN_2))
+            .ceil()
+            .div_euclid(8f64) as usize;
+        let suggested_size = BloomFilter::suggest_size_in_bytes(expected_elements, target_fp_rate);
         assert_eq!(suggested_size, 4_194_304);
         assert_eq!(suggested_size, theoretical_optimum.next_power_of_two())
     }

--- a/src/bloom_filter/bloom_test.rs
+++ b/src/bloom_filter/bloom_test.rs
@@ -1,62 +1,60 @@
 #[cfg(test)]
-mod tests {
-    use super::super::BloomFilter;
+use super::BloomFilter;
+// n: number of items in filter. p: false positive rate
+// m: number of bits in filter. k: number of hashers
+// n = ceil(m / (-k / log(1 - exp(log(p) / k))))
+// p = pow(1 - exp(-k / (m / n)), k)
+// m = ceil((n * log(p)) / log(1 / pow(2, log(2))));
+// k = round((m / n) * log(2));
 
-    // n: number of items in filter. p: false positive rate
-    // m: number of bits in filter. k: number of hashers
-    // n = ceil(m / (-k / log(1 - exp(log(p) / k))))
-    // p = pow(1 - exp(-k / (m / n)), k)
+#[cfg(test)]
+pub fn simplified_suggest_size(expected_elements: usize, target_fp_rate: f64) -> usize {
     // m = ceil((n * log(p)) / log(1 / pow(2, log(2))));
-    // k = round((m / n) * log(2));
+    use std::f64::consts::LN_2;
+    let theoretical_optimum = (expected_elements as f64 * target_fp_rate.ln() / (-LN_2 * LN_2))
+        .ceil()
+        .div_euclid(8.0) as usize;
+    theoretical_optimum.next_power_of_two()
+}
 
-    fn simplified_suggest_size(expected_elements: usize, target_fp_rate: f64) -> usize {
-        // m = ceil((n * log(p)) / log(1 / pow(2, log(2))));
-        use std::f64::consts::LN_2;
-        let theoretical_optimum = (expected_elements as f64 * target_fp_rate.ln() / (-LN_2 * LN_2))
-            .ceil()
-            .div_euclid(8.0) as usize;
-        theoretical_optimum.next_power_of_two()
-    }
+#[test]
+fn bloom_optimal_hasher_number() {
+    let size_in_bytes = 1_000_000_000;
+    let expected_elements = 1_000_000_000;
+    assert_eq!(
+        BloomFilter::optimal_number_of_hashers(size_in_bytes, expected_elements),
+        6
+    );
+    assert_eq!(
+        BloomFilter::optimal_number_of_hashers(1_000_000, 500_000),
+        12
+    )
+}
+#[test]
+fn bloom_test_prob_of_false_positive() {
+    // calculated from https://hur.st/bloomfilter/
+    let size_in_bytes = 1_000_000_000;
+    let expected_elements = 1_000_000_000;
+    let num_hashers = 8;
+    assert_eq!(
+        BloomFilter::prob_of_false_positive(size_in_bytes, expected_elements, num_hashers),
+        0.025_491_740_593_406_025 as f64
+    );
+    assert_eq!(
+        BloomFilter::prob_of_false_positive(1_048_576, 524288, 2),
+        0.013_806_979_447_406_826 as f64
+    )
+}
 
-    #[test]
-    fn bloom_optimal_hasher_number() {
-        let size_in_bytes = 1_000_000_000;
-        let expected_elements = 1_000_000_000;
-        assert_eq!(
-            BloomFilter::optimal_number_of_hashers(size_in_bytes, expected_elements),
-            6
-        );
-        assert_eq!(
-            BloomFilter::optimal_number_of_hashers(1_000_000, 500_000),
-            12
-        )
-    }
-    #[test]
-    fn bloom_test_prob_of_false_positive() {
-        // calculated from https://hur.st/bloomfilter/
-        let size_in_bytes = 1_000_000_000;
-        let expected_elements = 1_000_000_000;
-        let num_hashers = 8;
-        assert_eq!(
-            BloomFilter::prob_of_false_positive(size_in_bytes, expected_elements, num_hashers),
-            0.025_491_740_593_406_025 as f64
-        );
-        assert_eq!(
-            BloomFilter::prob_of_false_positive(1_048_576, 524288, 2),
-            0.013_806_979_447_406_826 as f64
-        )
-    }
+#[test]
+fn bloom_suggest_size() {
+    // it's hard to derive this exactly since the algorithm is doing closest power of 2
+    // instead of exact theoretical optimum
+    let expected_elements = 1_000_000;
+    let target_fp_rate = 0.0001 as f64;
 
-    #[test]
-    fn bloom_suggest_size() {
-        // it's hard to derive this exactly since the algorithm is doing closest power of 2
-        // instead of exact theoretical optimum
-        let expected_elements = 1_000_000;
-        let target_fp_rate = 0.0001 as f64;
-
-        let simplified_suggest_size = simplified_suggest_size(expected_elements, target_fp_rate);
-        let suggested_size = BloomFilter::suggest_size_in_bytes(expected_elements, target_fp_rate);
-        assert_eq!(suggested_size, 4_194_304);
-        assert_eq!(suggested_size, simplified_suggest_size)
-    }
+    let simplified_suggest_size = simplified_suggest_size(expected_elements, target_fp_rate);
+    let suggested_size = BloomFilter::suggest_size_in_bytes(expected_elements, target_fp_rate);
+    assert_eq!(suggested_size, 4_194_304);
+    assert_eq!(suggested_size, simplified_suggest_size)
 }

--- a/src/bloom_filter/bloom_test.rs
+++ b/src/bloom_filter/bloom_test.rs
@@ -10,7 +10,6 @@ use super::BloomFilter;
 #[cfg(test)]
 pub fn simplified_suggest_size(expected_elements: usize, target_fp_rate: f64) -> usize {
     // m = ceil((n * log(p)) / log(1 / pow(2, log(2))));
-    use std::cmp::{max, min};
     use std::f64::consts::LN_2;
     let theoretical_optimum = (expected_elements as f64 * target_fp_rate.ln() / (-LN_2 * LN_2))
         .ceil()
@@ -19,7 +18,7 @@ pub fn simplified_suggest_size(expected_elements: usize, target_fp_rate: f64) ->
 
     let min_size: usize = 1 << 20; //1 MiB
     let max_size: usize = usize::MAX / 2; // 9E18 bytes 8exbi-bytes
-    min(max(suggested_size, min_size), max_size)
+    suggested_size.clamp(min_size, max_size)
 }
 
 #[test]

--- a/src/bloom_filter/bloom_test.rs
+++ b/src/bloom_filter/bloom_test.rs
@@ -40,14 +40,18 @@ mod tests {
 
     #[test]
     fn bloom_suggest_size() {
-        use std::f64::consts::LN_2;
+        
         // it's hard to derive this exactly since the algorithm is doing closest power of 2
         // instead of exact theoretical optimum
         let expected_elements = 1_000_000;
         let target_fp_rate = 0.0001 as f64;
-        let theoretical_optimum = (expected_elements as f64 * target_fp_rate.ln() / (-LN_2 * LN_2))
+        fn simplified_suggest_size (expected_elements: usize, target_fp_rate: f64) {
+            use std::f64::consts::LN_2;
+            (expected_elements as f64 * target_fp_rate.ln() / (-LN_2 * LN_2))
             .ceil()
-            .div_euclid(8f64) as usize;
+            .div_euclid(8f64) as usize
+        }
+        let theoretical_optimum = simplified_suggest_size(expected_elements, target_fp_rate);
         let suggested_size = BloomFilter::suggest_size_in_bytes(expected_elements, target_fp_rate);
         assert_eq!(suggested_size, 4_194_304);
         assert_eq!(suggested_size, theoretical_optimum.next_power_of_two())

--- a/src/bloom_filter/bloom_test.rs
+++ b/src/bloom_filter/bloom_test.rs
@@ -9,6 +9,14 @@ mod tests {
     // m = ceil((n * log(p)) / log(1 / pow(2, log(2))));
     // k = round((m / n) * log(2));
 
+    fn simplified_suggest_size(expected_elements: usize, target_fp_rate: f64) -> usize {
+        // m = ceil((n * log(p)) / log(1 / pow(2, log(2))));
+        use std::f64::consts::LN_2;
+        (expected_elements as f64 * target_fp_rate.ln() / (-LN_2 * LN_2))
+            .ceil()
+            .div_euclid(8.0) as usize
+    }
+
     #[test]
     fn bloom_optimal_hasher_number() {
         let size_in_bytes = 1_000_000_000;
@@ -40,17 +48,11 @@ mod tests {
 
     #[test]
     fn bloom_suggest_size() {
-        
         // it's hard to derive this exactly since the algorithm is doing closest power of 2
         // instead of exact theoretical optimum
         let expected_elements = 1_000_000;
         let target_fp_rate = 0.0001 as f64;
-        fn simplified_suggest_size (expected_elements: usize, target_fp_rate: f64) {
-            use std::f64::consts::LN_2;
-            (expected_elements as f64 * target_fp_rate.ln() / (-LN_2 * LN_2))
-            .ceil()
-            .div_euclid(8f64) as usize
-        }
+        
         let theoretical_optimum = simplified_suggest_size(expected_elements, target_fp_rate);
         let suggested_size = BloomFilter::suggest_size_in_bytes(expected_elements, target_fp_rate);
         assert_eq!(suggested_size, 4_194_304);


### PR DESCRIPTION
I have further refactored some Bloom code and tests.

This would help reimplementing or adding alternatives to the current Bloom.
It isolates functions and math related to Bloom that could be shared.

I recognize that this is a significant refactor that might not align to the goals of the developers or project, but i do feel that it improves the readability, maintainability and extensibility of the code.

Although I have some more changes in mind, I bring this forward at this time so to discuss how to proceed (or not to) further.

One thing I did notice during the refactor was a pecularity of `pub fn suggest_size_in_bytes`
for clarity I extracted the value being compared out as `let max_size: usize = usize::MAX / 2; // 9E18 bytes 8exbi-bytes`

As per my comments there, that seems like an unrealistic upper bound. 
I would think something closer to 1 TiB would be more appropriate, or for it to be configurable. 
But I do not know the specific setup that allenai is using internally. So instead of trying to change it myself,
I bring it to your attention.


Also I am now feeling that we could just replace the `pub fn suggest_size_in_bytes`
with a function that I originally built for testing `pub fn simplified_suggest_size`
That function looks simpler (subjective) does not rely on loops, mutable variables or outside functions (since we can derive it from first principles regarding bloom maths).
We could still keep the original function (maybe swap places) for testing and comparison purposes as well.


These are the kind of discoveries and (hopefully) changes that I hoped to make through this refactor.