### PR TITLE
Fix a few issues of the FixedBucketsValTracker

### DIFF
--- a/python/dolma/core/analyzer.py
+++ b/python/dolma/core/analyzer.py
@@ -1,3 +1,4 @@
+import math
 import multiprocessing
 import re
 import shutil
@@ -27,7 +28,7 @@ def _make_tracker(type_: str = "fixed", **kwargs: int) -> BaseBucketApi:
     if type_ == "infer":
         return InferBucketsValTracker(**{"n": NUM_BINS, "b": BUFF_SIZE, **kwargs})
     elif type_ == "fixed":
-        return FixedBucketsValTracker(**{"n": NUM_BINS, **kwargs})
+        return FixedBucketsValTracker(**{"n": int(math.log10(NUM_BINS)), **kwargs})
     else:
         raise ValueError(f"Unknown tracker type {type_}")
 

--- a/python/dolma/core/binning.py
+++ b/python/dolma/core/binning.py
@@ -261,8 +261,8 @@ class FixedBucketsValTracker(BaseBucketApi):
     def get_bin_upper_bound(self, val: float) -> float:
         """Return the upper bound of the bin containing val"""
         m, e = math.frexp(val)
-        k = math.floor(m*self.n)+1 # Add one to obtain the next bin
-        return k/self.n * 2**e
+        k = math.floor(m * self.n) + 1  # Add one to obtain the next bin
+        return k / self.n * 2**e
 
     def summarize(self, n: int, density: bool = False) -> SummaryTuple:
         bins, counts = zip(*sorted((m / self.n * 2**e, c) for (m, e), c in self._bins.items()))
@@ -271,7 +271,7 @@ class FixedBucketsValTracker(BaseBucketApi):
             # if there are fewer than n buckets, return the buckets as is
             # To be consistent we also add the limit of the last bin, so the bins denote bin edges
             upper_bin = self.get_bin_upper_bound(max(float(b) for b in bins))
-            return SummaryTuple(counts=[int(c) for c in counts], bins=[float(b) for b in bins]+[upper_bin])
+            return SummaryTuple(counts=[int(c) for c in counts], bins=[float(b) for b in bins] + [upper_bin])
 
         # computing the weighted histograms
         new_counts, new_values = np.histogram(a=bins, bins=n, weights=counts, density=density)


### PR DESCRIPTION
1. Make the default number of bins of the internal tracker smaller so it does not cause numerical issues and/or memory problems.
2. Use floor() instead of int() (trunc) for rounding to have the same behaviour for positive and negative numbers.
3. Add an extra bin in the summarization method such that the number of bins in the summary is always "number of values"+1. This is consistent with the numpy histogram convention.

Fixes #70 