### PR TITLE
Add an option to improve tokenization shuffling 

### DIFF
--- a/python/dolma/cli/tokenizer.py
+++ b/python/dolma/cli/tokenizer.py
@@ -115,6 +115,10 @@ class TokenizationConfig:
         help="Number of sequences to tokenize before writing to disk.",
     )
     ring_size: int = field(default=8, help="Number of files to open in parallel for tokenization.")
+    sample_ring_prop: bool = field(
+        default=False,
+        help="Whether to sample the ring proportionally to the number of documents in each source.",
+    )
     max_size: int = field(
         default=1024 * 1024 * 1024,
         help="Maximum size of a file in bytes.",
@@ -196,4 +200,5 @@ class TokenizerCli(BaseCli):
                 metadata_dir=work_dirs.output,
                 max_size=parsed_config.max_size,
                 debug=parsed_config.debug,
+                sample_ring_prop=parsed_config.sample_ring_prop,
             )

--- a/python/dolma/core/paths.py
+++ b/python/dolma/core/paths.py
@@ -140,6 +140,17 @@ def delete_file(path: str, ignore_missing: bool = False) -> bool:
     return deleted
 
 
+def get_size(path) -> int:
+    """Get the size of a file"""
+    if not exists(path):
+        raise ValueError(f"Path {path} does not exist")
+    if is_dir(path):
+        raise ValueError(f"Path {path} is a directory")
+
+    fs = _get_fs(path)
+    return fs.info(path)["size"]
+
+
 def delete_dir(path: str, ignore_missing: bool = False) -> bool:
     """Delete a directory."""
 

--- a/python/dolma/tokenizer/executor.py
+++ b/python/dolma/tokenizer/executor.py
@@ -134,6 +134,7 @@ class MemMapParallelWriter(BaseParallelProcessor):
                         # we have reached the end of one of the file; move to the next!
                         cls.increment_progressbar(queue, files=1)
                         tokenizer_ring.pop(j)
+                        tokenizer_sizes.pop(j)
 
                         if len(tokenizer_ring) == 0:
                             # break if no more files to tokenize

--- a/python/dolma/tokenizer/tokenizer.py
+++ b/python/dolma/tokenizer/tokenizer.py
@@ -231,7 +231,7 @@ class Tokenizer:
         slices = []
         batch = []
         curr = 0
-        for input in inputs:
+        for input_ in inputs:
             paragraphs = [
                 # if a tokenizer adds a prefix in front of sequences, then the tokenization of the first
                 # symbol in each paragraph will be different depending on whether paragraphs are split
@@ -240,7 +240,7 @@ class Tokenizer:
                 (" " if self.tokenizer_has_prefix and i > 0 else "") + match.group()
                 # this regular expression keeps newlines at the beginning of paragraphs unless
                 # the paragraph is the first one in the document
-                for i, match in enumerate(re.finditer(r"(^\n*|\n+)[^\n]*", input))
+                for i, match in enumerate(re.finditer(r"(^\n*|\n+)[^\n]*", input_))
             ]
             slices.append((curr, curr + len(paragraphs)))
             batch.extend(paragraphs)


### PR DESCRIPTION
added flag `--sample_ring_prop` to `dolma tokens` (off by default). When set to true, sampling from files in the ring is done proportionally to their size so that smaller files are not disproportionately represented in the beginning of each file. 