### PR TITLE
Fix local installation on MacOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,12 @@ all = [
 ]
 
 [build-system]
-requires = ["maturin[patchelf]>=1.1,<2.0", "setuptools >= 61.0.0", "wheel"]
+requires = [
+    "setuptools >= 61.0.0",
+    "wheel",
+    "maturin[patchelf]>=1.1,<2.0 ; platform_system=='Linux'",
+    "maturin>=1.1,<2.0 ; platform_system!='Linux'",
+]
 build-backend = "maturin"
 
 


### PR DESCRIPTION
The optional python dependency of `maturin`, `patchelf`, can't be installed on Mac, and as far as I can tell isn't needed anyway.