### PR TITLE
Adds dclm fasttext classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dolma"
-version = "1.0.13"
+version = "1.0.14"
 description = "Data filters"
 license = { text = "Apache-2.0" }
 readme = "README.md"

--- a/python/dolma/taggers/quality.py
+++ b/python/dolma/taggers/quality.py
@@ -32,13 +32,15 @@ class DclmQualityClassifier(BaseFastTextTagger):
         # Extract the predicted label and its probability
         (pred_label, pred_prob) = pred
         pred_label = pred_label[0]
-        hq_prob = pred_prob[0]
+        probability_score = pred_prob[0]
 
         # If the predicted label is 'CC', adjust the probability of it being 'Wikipedia'
         if pred_label == "__label__cc":
-            hq_prob = 1 - hq_prob
+            probability_score = 1 - probability_score
 
-        return [Prediction(label=pred_label.replace("__label__", ""), score=hq_prob)]
+        label = pred_label.replace("__label__", "").replace("cc", "score").replace("hq", "score")
+
+        return [Prediction(label=label, score=probability_score)]
 
 
 @TaggerRegistry.add("dolma17-quality")

--- a/python/dolma/taggers/quality.py
+++ b/python/dolma/taggers/quality.py
@@ -15,6 +15,32 @@ from ..core.ft_tagger import BaseFastTextTagger, Prediction
 from ..core.registry import TaggerRegistry
 
 
+@TaggerRegistry.add("dclm-oh-eli5")
+class DclmQualityClassifier(BaseFastTextTagger):
+    MODEL_PATH = "https://huggingface.co/mlfoundations/fasttext-oh-eli5/resolve/main/openhermes_reddit_eli5_vs_rw_v2_bigram_200k_train.bin"
+
+    def __init__(self):
+        super().__init__(model_path=self.MODEL_PATH, model_mode=self.DOCUMENT_LEVEL_TAGGER)
+
+    def predict_slice(self, text_slice: TextSlice) -> Iterable[Prediction]:
+        # Note: This slice should always be the entire document
+
+        # Clean the input text by joining all lines into a single string
+        text = " ".join(text_slice.doc.strip().splitlines())
+        pred = self.classifier.predict(text)
+
+        # Extract the predicted label and its probability
+        (pred_label, pred_prob) = pred
+        pred_label = pred_label[0]
+        hq_prob = pred_prob[0]
+
+        # If the predicted label is 'CC', adjust the probability of it being 'Wikipedia'
+        if pred_label == "__label__cc":
+            hq_prob = 1 - hq_prob
+
+        return [Prediction(label=pred_label.replace("__label__", ""), score=hq_prob)]
+
+
 @TaggerRegistry.add("dolma17-quality")
 class Dolma17QualityClassifier(BaseFastTextTagger):
     MODEL_PATH = "https://dolma-artifacts.org/fasttext_models/dolma-1_7/cc_wiki_wikiref_sw_pes2o_adult_fakenews_math_books_openhermes.bin"  # noqa: E501


### PR DESCRIPTION
Example output:

```
{
  "id": "http://antichoiceantiawesome.blogspot.com/2012/01/",
  "attributes": {
    "dclm_fasttext__dclm_oh_eli5__score": [
      [
        0,
        14731,
        0.02031
      ]
    ]
  },
  "source": "dclm-hero-run-fasttext_for_HF"
}
{
  "id": "http://atomphotocomp.org/2018-judge/andrea-ulbrick/",
  "attributes": {
    "dclm_fasttext__dclm_oh_eli5__score": [
      [
        0,
        761,
        0.05164
      ]
    ]
  },
  "source": "dclm-hero-run-fasttext_for_HF"
}
```

```
---original---
0.07910442352294922
0.021570026874542236
0.024592816829681396
0.07086175680160522
0.221385657787323
0.06914657354354858
0.03766465187072754
0.02159935235977173
0.020305633544921875
0.051635682582855225

---dolma tagger---
0.0791
0.02157
0.02459
0.07086
0.22139
0.06915
0.03766
0.0216
0.02031
0.05164

```