### PR TITLE
Fill in Middle Implementation

### DIFF
--- a/python/dolma/__init__.py
+++ b/python/dolma/__init__.py
@@ -8,7 +8,7 @@ warnings.filterwarnings("ignore", message=r".*pkg_resources is deprecated.*", ca
 
 # must import taggers to register them
 # we import the rust extension here and wrap it in a python module
-from . import dolma as _dolma  # type: ignore   # noqa: E402
+from . import dolma as _dolma
 from .core import TaggerRegistry  # noqa: E402
 from .core.errors import DolmaRustPipelineError  # noqa: E402
 from .core.taggers import BaseTagger  # noqa: E402

--- a/python/dolma/__init__.py
+++ b/python/dolma/__init__.py
@@ -8,7 +8,7 @@ warnings.filterwarnings("ignore", message=r".*pkg_resources is deprecated.*", ca
 
 # must import taggers to register them
 # we import the rust extension here and wrap it in a python module
-from . import dolma as _dolma
+from . import dolma as _dolma  # noqa: E402
 from .core import TaggerRegistry  # noqa: E402
 from .core.errors import DolmaRustPipelineError  # noqa: E402
 from .core.taggers import BaseTagger  # noqa: E402

--- a/python/dolma/core/url_blocker.py
+++ b/python/dolma/core/url_blocker.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Union
 import smart_open
 import urllib3.util
 
-from .. import dolma as _dolma  # type: ignore   # noqa: E402
+from .. import dolma as _dolma
 
 
 class UrlBlocker:

--- a/python/dolma/data_transforms/fim.py
+++ b/python/dolma/data_transforms/fim.py
@@ -1,0 +1,76 @@
+"""
+Given a code document, perform FIM operations.
+"""
+
+import random
+from dataclasses import dataclass
+
+from dolma.core.data_types import DocumentWithMetadata
+
+
+@dataclass
+class FIMConfig:
+    fim_rate: float
+    psm_spm_split: float
+    file_separator_token: str
+    fim_prefix_token: str
+    fim_middle_token: str
+    fim_suffix_token: str
+
+
+class FillInMiddle:
+    def __init__(self, fim_config: FIMConfig) -> None:
+        self._config = fim_config
+
+    def perform_on_document(self, doc: DocumentWithMetadata) -> DocumentWithMetadata:
+        """Updates `text` field in-place"""
+        doc.text = self.perform_on_document_text(doc.text)
+        return doc
+
+    def perform_on_document_text(self, document_text: str) -> str:
+        files = document_text.split(self._config.file_separator_token)
+
+        new_files = []
+
+        for file in files:
+            if random.random() < self._config.fim_rate:
+                # Select two random character-level positions to break at
+                # anywhere in the document except the first and last chars.
+                position1 = random.randint(1, len(file) - 2)
+                while True:
+                    position2 = random.randint(1, len(file) - 2)
+                    if position1 != position2:
+                        break
+
+                if position1 > position2:
+                    swap = position1
+                    position1 = position2
+                    position2 = swap
+
+                if random.random() < self._config.psm_spm_split:
+                    # Place in Prefix-Suffix-Middle Order
+                    file_parts = [
+                        self._config.fim_prefix_token,
+                        file[0:position1],
+                        self._config.fim_suffix_token,
+                        file[position2:],
+                        self._config.fim_middle_token,
+                        file[position1:position2],
+                    ]
+                else:
+                    # Place in Suffix-Prefix-Middle order
+                    file_parts = [
+                        self._config.fim_suffix_token,
+                        file[position2:],
+                        self._config.fim_prefix_token,
+                        file[0:position1],
+                        self._config.fim_middle_token,
+                        file[position1:position2],
+                    ]
+
+                new_files.append("".join(file_parts))
+
+            else:
+                new_files.append(file)
+
+        return self._config.file_separator_token.join(new_files)

--- a/tests/python/test_fim.py
+++ b/tests/python/test_fim.py
@@ -25,12 +25,12 @@ CODE_FILE_1 = """
 def add_two_integers(a: int, b: int) -> int:
     sum = a + b
     return sum
-    
-    
+
+
 def multiply_two_integers(a: int, b: int) -> int:
     product = a + b
     return product
-    
+
 
 def sum_and_multiple(a: int, b: int, c: int) -> int:
     sum = add_two_integers(a, b)
@@ -51,7 +51,7 @@ def call_api(url: str, token: str, json: Dict[str, Any]) -> Dict[str, Any]:
         headers={"x-api-token": token},
         json=json
     )
-    
+
     return result.json()
 """
 

--- a/tests/python/test_fim.py
+++ b/tests/python/test_fim.py
@@ -1,0 +1,127 @@
+import re
+import unittest
+from uuid import uuid4
+
+from dolma.core.data_types import DocumentWithMetadata
+from dolma.data_transforms.fim import FillInMiddle, FIMConfig
+
+FILE_SEPARATOR = "<|file_sep|>"
+FIM_MIDDLE_TOKEN = "<|fim_mid|>"
+FIM_PREFIX_TOKEN = "<|fim_prefix|>"
+FIM_SUFFIX_TOKEN = "<|fim_suffix|>"
+
+
+def mk_document(text: str) -> DocumentWithMetadata:
+    return DocumentWithMetadata(source="somesource", version="1234", id=str(uuid4()), text=text, metadata={})
+
+
+def mk_text(num_files: int) -> str:
+    files = [CODE_FILE_1 if i % 2 == 0 else CODE_FILE_2 for i in range(num_files)]
+
+    return FILE_SEPARATOR.join(files)
+
+
+CODE_FILE_1 = """
+def add_two_integers(a: int, b: int) -> int:
+    sum = a + b
+    return sum
+    
+    
+def multiply_two_integers(a: int, b: int) -> int:
+    product = a + b
+    return product
+    
+
+def sum_and_multiple(a: int, b: int, c: int) -> int:
+    sum = add_two_integers(a, b)
+    product = multiply_two_integers(sum, c)
+    return product
+"""
+
+
+CODE_FILE_2 = """
+from typing import Any
+
+import requests
+
+
+def call_api(url: str, token: str, json: Dict[str, Any]) -> Dict[str, Any]:
+    result = requests.post(
+        url,
+        headers={"x-api-token": token},
+        json=json
+    )
+    
+    return result.json()
+"""
+
+
+class TestFillInMiddle(unittest.TestCase):
+    def test__fim_reordering_works(self) -> None:
+        # First, Prefix-Suffix-Middle
+        psm_config = FIMConfig(
+            fim_rate=1.0,
+            psm_spm_split=1.0,
+            file_separator_token=FILE_SEPARATOR,
+            fim_prefix_token=FIM_PREFIX_TOKEN,
+            fim_middle_token=FIM_MIDDLE_TOKEN,
+            fim_suffix_token=FIM_SUFFIX_TOKEN,
+        )
+        psm_fim = FillInMiddle(psm_config)
+        original_text = mk_text(1)
+        psm_reordered = psm_fim.perform_on_document(mk_document(original_text))
+        final_text = psm_reordered.text
+        prefix_plus_prefix_token, rest = final_text.split(FIM_SUFFIX_TOKEN)
+        _, prefix = prefix_plus_prefix_token.split(FIM_PREFIX_TOKEN)
+        suffix, middle = rest.split(FIM_MIDDLE_TOKEN)
+
+        self.assertEqual(prefix + middle + suffix, original_text)
+
+        # Next, Suffix-Prefix-Middle
+        spm_config = FIMConfig(
+            fim_rate=1.0,
+            psm_spm_split=0,
+            file_separator_token=FILE_SEPARATOR,
+            fim_prefix_token=FIM_PREFIX_TOKEN,
+            fim_middle_token=FIM_MIDDLE_TOKEN,
+            fim_suffix_token=FIM_SUFFIX_TOKEN,
+        )
+        spm_fim = FillInMiddle(spm_config)
+        original_text = mk_text(1)
+        spm_reordered = spm_fim.perform_on_document(mk_document(original_text))
+        final_text = spm_reordered.text
+        suffix_plus_suffix_token, rest = final_text.split(FIM_PREFIX_TOKEN)
+        _, suffix = suffix_plus_suffix_token.split(FIM_SUFFIX_TOKEN)
+        prefix, middle = rest.split(FIM_MIDDLE_TOKEN)
+
+        self.assertEqual(prefix + middle + suffix, original_text)
+
+    def test__fim_and_reordering_split_rates_work(self) -> None:
+        config = FIMConfig(
+            fim_rate=0.5,
+            psm_spm_split=0.5,
+            file_separator_token=FILE_SEPARATOR,
+            fim_prefix_token=FIM_PREFIX_TOKEN,
+            fim_middle_token=FIM_MIDDLE_TOKEN,
+            fim_suffix_token=FIM_SUFFIX_TOKEN,
+        )
+        fim = FillInMiddle(config)
+        reordered = fim.perform_on_document(mk_document(mk_text(100_000)))
+        files = reordered.text.split(FILE_SEPARATOR)
+
+        self.assertEqual(len(files), 100_000)
+
+        psm_reordered = 0
+        spm_reordered = 0
+
+        psm_match = r"<\|fim_prefix\|>.+<\|fim_suffix\|>.+<\|fim_mid\|>.+"
+        spm_match = r"<\|fim_suffix\|>.+<\|fim_prefix\|>.+<\|fim_mid\|>.+"
+
+        for file in files:
+            for _ in re.finditer(psm_match, file, re.DOTALL):
+                psm_reordered += 1
+            for _ in re.finditer(spm_match, file, re.DOTALL):
+                spm_reordered += 1
+
+        self.assertAlmostEqual((psm_reordered + spm_reordered) / 100_000, 0.5, 2)
+        self.assertAlmostEqual(psm_reordered / (psm_reordered + spm_reordered), 0.5, 2)

--- a/tests/python/test_fim.py
+++ b/tests/python/test_fim.py
@@ -106,10 +106,10 @@ class TestFillInMiddle(unittest.TestCase):
             fim_suffix_token=FIM_SUFFIX_TOKEN,
         )
         fim = FillInMiddle(config)
-        reordered = fim.perform_on_document(mk_document(mk_text(100_000)))
+        reordered = fim.perform_on_document(mk_document(mk_text(300_000)))
         files = reordered.text.split(FILE_SEPARATOR)
 
-        self.assertEqual(len(files), 100_000)
+        self.assertEqual(len(files), 300_000)
 
         psm_reordered = 0
         spm_reordered = 0
@@ -123,5 +123,26 @@ class TestFillInMiddle(unittest.TestCase):
             for _ in re.finditer(spm_match, file, re.DOTALL):
                 spm_reordered += 1
 
-        self.assertAlmostEqual((psm_reordered + spm_reordered) / 100_000, 0.5, 2)
+        self.assertAlmostEqual((psm_reordered + spm_reordered) / 300_000, 0.5, 2)
         self.assertAlmostEqual(psm_reordered / (psm_reordered + spm_reordered), 0.5, 2)
+
+    def test__fim_needs_at_least_five_characters_to_rearrange(self) -> None:
+        config = FIMConfig(
+            fim_rate=1,
+            psm_spm_split=1,
+            file_separator_token=FILE_SEPARATOR,
+            fim_prefix_token=FIM_PREFIX_TOKEN,
+            fim_middle_token=FIM_MIDDLE_TOKEN,
+            fim_suffix_token=FIM_SUFFIX_TOKEN,
+        )
+        fim = FillInMiddle(config)
+
+        for i in range(5):
+            starting_string = "a" * i or ""
+            document = mk_document(text=starting_string)
+            reordered = fim.perform_on_document(document)
+
+            if i < 5:
+                self.assertEqual(reordered.text, starting_string)
+            else:
+                self.assertTrue(FIM_PREFIX_TOKEN in reordered.text)


### PR DESCRIPTION
Implements character-level fill-in-middle document text reordering.

Splits a file boundary delimited document text into constituent source files
and applies reordering logic. Class is implemented in rust exposed via
PyO3 up to dolma toolkit library, and is parameterized on the following:

1. rate to apply FIM reordering
2. rate to apply Prefix-Suffix-Middle vs Suffix-Prefix-Middle reordering
3. sentinel tokens (file boundary and FIM specific)