### PR TITLE
Bump artifacts version to 4.4.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -202,7 +202,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install --yes --upgrade build-essential cmake protobuf-compiler libssl-dev glibc-source musl-tools
       - name: Upload wheels
-        uses: actions/upload-artifact@v4.4
+        uses: actions/upload-artifact@v4.4.1
         with:
           overwrite: true
           name: release-wheel-linux-${{ matrix.target }}-${{ github.run_id }}
@@ -228,7 +228,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter
       - name: Upload wheels
-        uses: actions/upload-artifact@v4.4
+        uses: actions/upload-artifact@v4.4.1
         with:
           overwrite: true
           name: release-wheel-windows-${{ matrix.target }}-${{ github.run_id }}
@@ -253,7 +253,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter
       - name: Upload wheels
-        uses: actions/upload-artifact@v4.4
+        uses: actions/upload-artifact@v4.4.1
         with:
           overwrite: true
           name: release-wheel-macos-${{ matrix.target }}-${{ github.run_id }}
@@ -271,7 +271,7 @@ jobs:
           command: sdist
           args: --out dist
       - name: Upload sdist
-        uses: actions/upload-artifact@v4.4
+        uses: actions/upload-artifact@v4.4.1
         with:
           overwrite: true
           name: release-sdist-${{ github.run_id }}


### PR DESCRIPTION
Appears that v4.4 no longer resolves to a package version.

See https://github.com/allenai/dolma/actions/runs/13659869276/job/38254598669

Working on 4.4.1 feature branch: https://github.com/allenai/dolma/actions/runs/13682645512/job/38258572016