### PR TITLE
Use original s3 path to delete local cache

### DIFF
--- a/src/shard.rs
+++ b/src/shard.rs
@@ -476,7 +476,7 @@ impl Shard {
                         }
                     }
                 }
-                cache.finalize_input(local_docs_file.to_str().unwrap())?;
+                cache.finalize_input(&input_path.doc_path)?;
                 for (index, attribute_path) in
                     find_objects_matching_patterns(&input_path.attribute_paths)
                         .unwrap()


### PR DESCRIPTION
`finalize_input` checks whether the path begins with s3:// and then recomputes the local path, so we should pass the original input path instead of the local one