### PR TITLE
FIM script modifications

### DIFF
--- a/contrib/fill-in-middle/Cargo.toml
+++ b/contrib/fill-in-middle/Cargo.toml
@@ -5,8 +5,10 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.29", features = ["derive"] }
+glob = "0.3.2"
 mj_io = "0.1.2"
 rand = "0.9.0"
 rayon = "1.10.0"
 regex = "1.11.1"
 serde_json = "1.0.138"
+zstd = "0.12"


### PR DESCRIPTION
This represents two adjustments to the existing FIM script:
- allows read/write of zstd compressed files
- modifies glob handling to permit input pattern specified in docs (was throwing an error in mj_io module)

```
cargo run --release -- \
    --inputs 'data/input/*jsonl' \
```