### PR TITLE
Fix catastrophic regex backtracking in NotAlphanumParagraphV1 tagger

### DIFF
--- a/python/dolma/taggers/punctuation.py
+++ b/python/dolma/taggers/punctuation.py
@@ -18,7 +18,7 @@ class NotAlphanumParagraphV1(BaseTagger):
             "\U0001f300-\U0001f64f"
             "\U0001f680-\U0001f6ff"
             "\u2600-\u26ff\u2700-\u27bf"
-            r"]+"
+            r"]"
             r")+$",
             regex.UNICODE,
         )


### PR DESCRIPTION
## Summary
- Remove redundant `+` quantifier from the emoji character class in `NotAlphanumParagraphV1`'s regex pattern (`python/dolma/taggers/punctuation.py`)
- The pattern `[...]+()+$` has nested quantifiers that cause exponential backtracking on long emoji sequences; the outer `()+` already handles repetition, making the inner `+` both redundant and harmful

Fixes #123

## Test plan
- [ ] Run existing tests for the punctuation tagger
- [ ] Verify the tagger completes in reasonable time on inputs with long emoji sequences (e.g., 1000+ consecutive emoji characters)
- [ ] Confirm the tagger still correctly identifies paragraphs that are entirely punctuation/emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)