### PR TITLE
Fix IGNORE_IP_REGEX_START never matching localhost IPs

### DIFF
--- a/python/dolma/taggers/url.py
+++ b/python/dolma/taggers/url.py
@@ -59,7 +59,7 @@ class BaseUrlTagger(BaseTaggerWithMetadata):
     URL_METADATA_KEY = "url"
     MAYBE_IP_REGEX = re.compile(r"([0-9a-f\.\:]+)")
     IGNORE_IP_REGEX = re.compile(r"(127\.0\.0\.1|0\.0\.0\.0|::1)")
-    IGNORE_IP_REGEX_START = re.compile(r"^{IGNORE_IP_REGEX.pattern}")
+    IGNORE_IP_REGEX_START = re.compile(f"^{IGNORE_IP_REGEX.pattern}")
     URL_REGEX = re.compile(r"(([a-z0-9\-_]+\.?){2,}|localhost|localdomain)")
     ONLY_URL_REGEX = re.compile(f"^{URL_REGEX.pattern}")
     ADP_FORMAT_REGEX = re.compile(f"\\|+{URL_REGEX.pattern}\\^")


### PR DESCRIPTION
## Summary

`BaseUrlTagger.IGNORE_IP_REGEX_START` uses an `r"..."` (raw string) instead of `f"..."` (f-string), so the regex is compiled as the literal text `^{IGNORE_IP_REGEX.pattern}` rather than expanding to `^(127\.0\.0\.1|0\.0\.0\.0|::1)`.

**Bug:** Line 62 — `re.compile(r"^{IGNORE_IP_REGEX.pattern}")` never matches any real IP.  
**Impact:** The localhost check at line 97 (`if not self.IGNORE_IP_REGEX_START.match(...)`) always passes, so `127.0.0.1`, `0.0.0.0`, and `::1` are incorrectly yielded as blocklist URLs instead of being filtered out.  
**Evidence:** The adjacent `ONLY_URL_REGEX` (line 64) and `ADP_FORMAT_REGEX` (line 65) both correctly use `f"..."` for the same interpolation pattern.

**Fix:** Change `r"..."` → `f"..."` on line 62.

## Test plan
- [x] Confirmed with Python REPL that the r-string compiles to literal `^{IGNORE_IP_REGEX.pattern}`
- [x] Confirmed the f-string correctly expands to `^(127\.0\.0\.1|0\.0\.0\.0|::1)`
- [x] Adjacent class attributes use f-strings for the same pattern — consistent fix
- [x] One-character change, no side effects