### PR TITLE
Fix wrong denominator in fraction_of_characters_in_duplicate_lines

### DIFF
--- a/python/dolma/taggers/gopher.py
+++ b/python/dolma/taggers/gopher.py
@@ -194,7 +194,7 @@ def get_attributes(text: str, ignore_empty_lines: bool = False) -> GopherAttribu
         )
         attrs.fraction_of_characters_in_duplicate_lines = sum(
             len(line) * count for line, count in line_counts.items() if count > 1
-        ) / max(character_count, 1)
+        ) / max(attrs.character_count, 1)
     except Exception as e:
         logging.exception(f"Error processing text {e}: {text[:200]}")
 


### PR DESCRIPTION
## Bug

In `get_attributes()`, the local variable `character_count` is the sum of word lengths (whitespace excluded):

```python
character_count = sum(len(word) for word in words)  # line 148
```

This is used as the denominator for `fraction_of_characters_in_duplicate_lines`:

```python
sum(len(line) * count ...) / max(character_count, 1)  # line 195-197
```

But the numerator uses `len(line)`, which includes spaces. Since the denominator excludes whitespace while the numerator includes it, the ratio can exceed 1.0 for documents with duplicate lines — e.g., `"hello world\nhello world\n"` produces 22/10 = 2.2.

## Fix

Use `attrs.character_count` (= `len(text)`, set on line 141) as the denominator, which includes all characters and is consistent with the numerator.

Note: `character_count` (word-length sum) is the correct denominator for the ngram-based metrics on lines 168/171-174, where the numerator is also word-length based. Only the duplicate-lines metric has this mismatch.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>