### PR TITLE
Fix off-by-one in CodeCopyrightTagger._score span length

### DIFF
--- a/python/dolma/taggers/code/code_taggers.py
+++ b/python/dolma/taggers/code/code_taggers.py
@@ -138,7 +138,7 @@ class CodeCopyrightTagger(BaseTagger):
             else:
                 span = copyright_spans[0]
                 # percentage of content affected
-                score = (span.end - span.start + 1) * 1.0 / len(text)
+                score = (span.end - span.start) * 1.0 / len(text)
         except ZeroDivisionError:
             score = -1.0
         return score


### PR DESCRIPTION
## Summary

`CodeCopyrightTagger._score` computes copyright coverage as:

```python
score = (span.end - span.start + 1) * 1.0 / len(text)
```

The `+ 1` is incorrect. `Span` uses Python's exclusive-end convention — `Span.__len__` returns `self.end - self.start`, and all other span-length calculations in the codebase use `end - start` without `+ 1`. The extra `+ 1` inflates the score by one character per span, making copyright coverage systematically too high.

**Fix**: Remove the `+ 1` to match the `Span` convention.

## Test plan

- [x] Verified `Span.__len__` returns `end - start` (exclusive end, no `+ 1`)
- [ ] Existing tests should continue to pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)