### PR TITLE
Fix catastrophic backtracking in not_alphanum_paragraph_v1 regex

### DIFF
--- a/python/dolma/taggers/punctuation.py
+++ b/python/dolma/taggers/punctuation.py
@@ -18,7 +18,7 @@ class NotAlphanumParagraphV1(BaseTagger):
             "\U0001f300-\U0001f64f"
             "\U0001f680-\U0001f6ff"
             "\u2600-\u26ff\u2700-\u27bf"
-            r"]+"
+            r"]"
             r")+$",
             regex.UNICODE,
         )


### PR DESCRIPTION
## Bug

The `not_alphanum_paragraph_v1` tagger's regex contains a nested quantifier pattern `[emoji-ranges]+` inside `(...)+`, creating a classic `(X+)+` catastrophic backtracking scenario. As reported in #123, ~44 emoji characters cause 64 seconds of processing, and ~68 emoji characters cause the tagger to hang indefinitely.

## Root cause

Line 21 of `python/dolma/taggers/punctuation.py`: the inner `+` on the emoji character class is redundant because the outer group `)+` already handles matching multiple characters. Together they form a nested quantifier that causes the regex engine to explore exponentially many partitions.

## Fix

Remove the inner `+` (1-character deletion). The outer `)+` still matches one-or-more of any character in the alternation (punctuation, whitespace, or emoji), preserving the regex's matching semantics while eliminating exponential backtracking.

Closes #123