### PR TITLE
Fix whitespace_tokenizer_v1 counting tokens + 1 via regex.split

### DIFF
--- a/python/dolma/taggers/length.py
+++ b/python/dolma/taggers/length.py
@@ -60,7 +60,7 @@ class WhitespaceLengthV1(BaseTagger):
     WHITESPACE_REGEX = regex.compile(r"\w+|[^\w\s]+")
 
     def predict(self, doc: Document) -> DocResult:
-        score = len(self.WHITESPACE_REGEX.split(doc.text))
+        score = len(self.WHITESPACE_REGEX.findall(doc.text))
         return DocResult(doc=doc, spans=[Span(start=0, end=len(doc.text), type="length", score=score)])
 
 
@@ -68,7 +68,7 @@ class WhitespaceLengthV1(BaseTagger):
 class WhitespaceLengthParagraphsV1(WhitespaceLengthV1):
     def predict(self, doc: Document) -> DocResult:
         spans = [
-            Span(start=p.start, end=p.end, type="paragraph", score=len(self.WHITESPACE_REGEX.split(p.text)))
+            Span(start=p.start, end=p.end, type="paragraph", score=len(self.WHITESPACE_REGEX.findall(p.text)))
             for p in split_paragraphs(doc.text)
         ]
         spans.append(Span(start=0, end=len(doc.text), type="document", score=sum(s.score for s in spans)))


### PR DESCRIPTION
## Bug

\`whitespace_tokenizer_v1\` (and its paragraph variant \`whitespace_tokenizer_with_paragraphs_v1\`) in \`python/dolma/taggers/length.py\` score every document's token count as **N + 1**, and score an empty document as **1** rather than **0**.

## Root cause

The score is computed with \`regex.split\`, not \`regex.findall\`:

\`\`\`python
WHITESPACE_REGEX = regex.compile(r"\w+|[^\w\s]+")

def predict(self, doc: Document) -> DocResult:
    score = len(self.WHITESPACE_REGEX.split(doc.text))
    ...
\`\`\`

\`regex.split\` splits **around** each token the regex matches and returns the non-matching fragments (including the leading / trailing fragments). For any non-empty input that matches at least once, that yields \`num_tokens + 1\` elements; for empty input it yields \`[""]\` (length 1). Concretely:

\`\`\`text
""                -> split: 1   findall: 0
"hello"           -> split: 2   findall: 1
"hello world"     -> split: 3   findall: 2
"hello, world!"   -> split: 5   findall: 4
\`\`\`

\`docs/taggers.md\` describes \`whitespace_tokenizer_v1\` as "Count the number of whitespace-separated tokens in each document", and \`WHITESPACE_REGEX\` is written to **match** tokens (word runs and non-word-non-whitespace runs), so the intended count is \`findall\`, not \`split\`.

## Fix

Use \`WHITESPACE_REGEX.findall\` instead of \`WHITESPACE_REGEX.split\` in both \`WhitespaceLengthV1.predict\` and \`WhitespaceLengthParagraphsV1.predict\`. The score now equals the actual number of matched tokens, and an empty document correctly scores 0 — which matters for any downstream filter gated on \`score > 0\`.