### PR TITLE
Fix BaseBucketApi.add incrementing _total per call instead of per value

### DIFF
--- a/python/dolma/core/binning.py
+++ b/python/dolma/core/binning.py
@@ -232,7 +232,7 @@ class BaseBucketApi:
 
         for value, count in zip(values, counts):
             self._add(value, count)
-            self._total += 1
+            self._total += count
             self._sum += value * count
 
     def add_summary(self, summary: SummaryTuple):


### PR DESCRIPTION
## Bug

\`BaseBucketApi.total\`'s docstring is _\"Return the total number of values added to the tracker\"_, but \`BaseBucketApi.add\` does:

\`\`\`python
for value, count in zip(values, counts):
    self._add(value, count)
    self._total += 1
    self._sum += value * count
\`\`\`

So \`tracker.add(values=[v0, v1], counts=[5, 3])\` ends up with \`_total == 2\` instead of \`8\`, while \`_sum\` is correctly weighted by \`count\`.

## Root cause

The increment is per loop iteration rather than per observation. This is exactly the discrepancy that \`add_summary\` works around:

\`\`\`python
def add_summary(self, summary: SummaryTuple):
    prev_count, prev_sum = self._total, self._sum
    self.add(summary.bins, summary.counts)
    # override the total and sum with the previous values, thats' because otherwise they are approximate
    self._total = prev_count + summary.total
    self._sum = prev_sum + summary.sum
\`\`\`

Without the override, the total after rebuilding a tracker via \`SummarySpec.to_tracker(...)\` (which calls \`tracker.add(values=self.bins, counts=self.counts)\`) reflects only the number of bins, not the original observation count.

## Fix

Increment \`_total\` by \`count\`, matching \`_sum\`'s per-value accumulation and the documented contract. The \`add_summary\` override remains correct (it now agrees with what \`add\` produces).