### PR TITLE
Fix ft_dataset write_results dropping messages and opening output in binary mode

### DIFF
--- a/python/dolma/core/ft_dataset.py
+++ b/python/dolma/core/ft_dataset.py
@@ -100,7 +100,7 @@ def process_file(config: Config, q: "Queue[str]", flag: Event, label: str, fn):
 def write_results(config: Config, q: "Queue[str]", flag: Event):
     written = 0
 
-    with smart_open.open(config.out_path, "wb") as o:
+    with smart_open.open(config.out_path, "w") as o:
         while True:
             msg = q.get()
 
@@ -108,7 +108,7 @@ def write_results(config: Config, q: "Queue[str]", flag: Event):
                 break
 
             if not flag.is_set():
-                o.write(q.get())
+                o.write(msg)
                 o.write("\n")
                 written += 1
 


### PR DESCRIPTION
## Bug

`write_results` in `python/dolma/core/ft_dataset.py`:

```python
with smart_open.open(config.out_path, "wb") as o:
    while True:
        msg = q.get()

        if msg == _WRITER_EXIT_MSG:
            break

        if not flag.is_set():
            o.write(q.get())
            o.write("\n")
            written += 1
```

Two bugs in five lines:

1. `o.write(q.get())` calls `q.get()` a **second** time, so the `msg` retrieved at the top of the loop is discarded (only used for the exit check) and a fresh message is pulled and written. Every other producer message is silently dropped, and the write itself can even pull and write the `_WRITER_EXIT_MSG` sentinel (`"__WRITE__EXIT__"`) into the output file, leaving the writer blocked on the next `q.get()`.

2. The file is opened with mode `"wb"` (binary), but the producer (`process_file`) puts plain `str` values on the queue (`q.put(f"__label__{label} {final_text}")`) and line 112 writes the literal `"\n"`. Both calls raise `TypeError: a bytes-like object is required, not 'str'` the moment any record is produced.

## Root cause

1. Typo / copy-paste: the retrieved `msg` was never written — `q.get()` was called twice.
2. Mode mismatch between the opened file (binary) and the `str` payloads produced upstream.

## Fix

- Write the already-retrieved `msg` (`o.write(msg)`).
- Open the output path in text mode (`"w"`) to match the `str` payloads.

No change to the sentinel-based shutdown or the `flag`-based early-exit logic.