### PR TITLE
Fix LinguaTagger ImportError referring to langdetect instead of lingua

### DIFF
--- a/python/dolma/taggers/language.py
+++ b/python/dolma/taggers/language.py
@@ -254,7 +254,7 @@ class LinguaTagger(BaseLanguageTagger):
     def __init__(self) -> None:
         super().__init__()
         if not LINGUA_AVAILABLE:
-            raise ImportError("langdetect is not installed, please run `pip install dolma[lang]`.")
+            raise ImportError("lingua is not installed, please run `pip install dolma[lang]`.")
         self.detector = LanguageDetectorBuilder.from_languages(*Language.all()).build()
 
     def predict_text(self, text: str) -> List[Tuple[str, float]]:


### PR DESCRIPTION
### Bug
`LinguaTagger.__init__` checks `LINGUA_AVAILABLE` but raises `ImportError("langdetect is not installed, ...")`, pointing users to the wrong package.

https://github.com/allenai/dolma/blob/96f8b07/python/dolma/taggers/language.py#L254-L257

```python
def __init__(self) -> None:
    super().__init__()
    if not LINGUA_AVAILABLE:
        raise ImportError("langdetect is not installed, please run `pip install dolma[lang]`.")
    self.detector = LanguageDetectorBuilder.from_languages(*Language.all()).build()
```

### Root cause
Copy-paste from `LangdetectTagger.__init__` at line 204-206, which correctly reports `langdetect` when `LANGDETECT_AVAILABLE` is false. The message in `LinguaTagger` was never updated for the new availability flag.

### Fix
Change the message to `"lingua is not installed, ..."` so it names the actually-missing package. The `pip install dolma[lang]` hint is unchanged because the `lang` extras include `lingua-language-detector`.