### PR TITLE
Rename TokenizerConfig.__post__init__ to __post_init__

### DIFF
--- a/python/dolma/cli/tokenizer.py
+++ b/python/dolma/cli/tokenizer.py
@@ -51,7 +51,7 @@ class TokenizerConfig:
         help="Whether to encode special tokens in the tokenized output, e.g. splitting '<s>' into '<', 's', '>'.",
     )
 
-    def __post__init__(self):
+    def __post_init__(self):
         logger = get_logger(__file__)
 
         if self.eos_token_id is None:


### PR DESCRIPTION
## Bug

In `python/dolma/cli/tokenizer.py`, `TokenizerConfig` declares

```python
def __post__init__(self):
    ...
    if self.pad_token_id is None:
        self.pad_token_id = self.eos_token_id
    ...
```

but the method name has an extra underscore. The `@dataclass` machinery
only invokes `__post_init__` (single underscore between `post` and
`init`), so this method is never called.

## Root cause

Plain typo in the method name (`__post__init__` instead of
`__post_init__`). Nothing else in the file references it, so the typo
is silent: the code compiles and imports fine, and the tokenizer CLI
just runs without the intended post-init validation.

## Why the fix is correct

Renaming to `__post_init__` makes `@dataclass` invoke it exactly as
intended:

- `pad_token_id` falls back to `eos_token_id` when the user doesn't
  pass one (line 66). Without the fix, `pad_token_id` stays `None`
  and propagates into `tokenize_in_parallel(..., pad_token_id=None, ...)`
  at line 222 of `TokenizerCli.run`.
- The "NO EOS TOKEN PROVIDED", "NO BOS TOKEN PROVIDED", and
  "segment_before_tokenization is experimental" warnings fire for
  misconfigured runs, instead of being silently skipped.

This is a one-character change, no logic in the body of the method is
touched, and no call site needs to change because nothing was
explicitly calling the misnamed method.

## Change

`python/dolma/cli/tokenizer.py`: `def __post__init__(self):` →
`def __post_init__(self):`.