### PR TITLE
Fix BaseDomainTagger.clean_url mangling hostnames starting with 'w'

### DIFF
--- a/python/dolma/taggers/url.py
+++ b/python/dolma/taggers/url.py
@@ -143,7 +143,7 @@ class BaseDomainTagger(BaseUrlTagger):
             hostname = urllib3.util.parse_url(url).host
             if not hostname:
                 return
-            yield (hostname := hostname.lstrip("www."))
+            yield (hostname := hostname.removeprefix("www."))
             yield f"www.{hostname}"
 
 


### PR DESCRIPTION
## Bug

`BaseDomainTagger.clean_url` in `python/dolma/taggers/url.py:146` corrupts any hostname that begins with `w` (or with a `.`) before checking it against the blocklist, so many common domains silently bypass the blocklist check:

```python
>>> 'wikipedia.org'.lstrip('www.')
'ikipedia.org'
>>> 'weather.com'.lstrip('www.')
'eather.com'
>>> 'walmart.com'.lstrip('www.')
'almart.com'
>>> 'web.archive.org'.lstrip('www.')
'eb.archive.org'
```

Both the stripped yield and the subsequent ``f"www.{hostname}"`` yield use the corrupted hostname, so neither form of the lookup matches the blocklist. This affects every `BaseDomainTagger` subclass, including `DomainBlocklistUniversiteToulouseCapitoleTagger` and `DomainBlocklistPhishingTagger`.

## Root cause

`str.lstrip(chars)` takes `chars` as a **set of characters** to strip, not a literal prefix. `lstrip("www.")` strips any combination of `{'w', '.'}` from the left of the string. Confirmed on the exact Python used by the project (`requires-python = ">=3.10,<3.13"` in `pyproject.toml`).

## Fix

Replace `hostname.lstrip("www.")` with `hostname.removeprefix("www.")`, which removes only a literal `www.` prefix and is a no-op otherwise. `str.removeprefix` has been available since Python 3.9, so it's safely usable under the project's `>=3.10` floor.

## Why this is correct

- For `"www.example.com"` the result is unchanged (`"example.com"`), preserving current behavior on well-formed `www.` prefixes.
- For any hostname that doesn't start with `www.` the hostname is returned intact, so the blocklist check runs against the real domain.
- The following `yield f"www.{hostname}"` continues to produce both forms of the lookup (with and without `www.`), now correctly.
- No behavioral change for existing tests in `tests/python/test_urls.py` (none of them exercise `w*` domains); the fix is a 1-char diff.