### PR TITLE
Fix Dolma17QualityClassifier.predict_slice crashing on empty/whitespace text

### DIFF
--- a/python/dolma/taggers/quality.py
+++ b/python/dolma/taggers/quality.py
@@ -59,7 +59,10 @@ class Dolma17QualityClassifier(BaseFastTextTagger):
         return tokens
 
     def predict_slice(self, text_slice: TextSlice) -> Iterable[Prediction]:
-        tokens, _ = zip(*self.preprocess(text_slice.text))
+        pairs = self.preprocess(text_slice.text)
+        if not pairs:
+            return []
+        tokens, _ = zip(*pairs)
         preds = self.classifier.predict(" ".join(tokens), k=-1)
         out = [
             Prediction(label=label.replace("__label__", ""), score=score)


### PR DESCRIPTION
**Bug:** `Dolma17QualityClassifier.predict_slice` raises `ValueError: not enough values to unpack` when `text_slice.text` is empty or contains only whitespace.

**Root cause:** `self.preprocess(text)` strips whitespace and then splits on whitespace, returning `[]` for empty or whitespace-only input. The next line `tokens, _ = zip(*self.preprocess(...))` expands to `zip(*[])` which returns an empty iterator. Tuple-unpacking an empty iterator with `tokens, _ = ...` raises `ValueError` because there are no values to unpack.

**Why the fix is correct:** Guard with `if not pairs: return []` before the unpack. An empty document has no tokens to classify, so returning an empty prediction list is consistent with how other taggers handle empty inputs (e.g. `DclmQualityClassifier` falls back to fasttext's own empty-string handling). The early return avoids the crash without altering behaviour for non-empty documents.