### PR TITLE
fix(taggers): replace hf:// scheme with HTTPS URL in CodeProseCompositionClassifier

### DIFF
--- a/python/dolma/taggers/code_composition.py
+++ b/python/dolma/taggers/code_composition.py
@@ -24,7 +24,7 @@ from ..core.registry import TaggerRegistry
 
 @TaggerRegistry.add("code_composition")
 class CodeProseCompositionClassifier(BaseFastTextTagger):
-    MODEL_PATH = "hf://techarb/code-prose-composition/code-comment-prose-model.bin"  # noqa: E501
+    MODEL_PATH = "https://huggingface.co/techarb/code-prose-composition/resolve/main/code-comment-prose-model.bin"
 
     def __init__(self):
         super().__init__(model_path=self.MODEL_PATH, model_mode=self.DOCUMENT_LEVEL_TAGGER)


### PR DESCRIPTION
**Bug:** `CodeProseCompositionClassifier.MODEL_PATH` uses the `hf://` URI scheme, which is not supported by `smart_open` (the library dolma uses to download FastText models):

```python
MODEL_PATH = "hf://techarb/code-prose-composition/code-comment-prose-model.bin"
```

This causes a connection/scheme error when the tagger is instantiated, making the classifier completely unusable. The entire test class for this tagger is currently disabled because of this:

```python
@unittest.skip("Disable until path hf:// for code prose classifier is fixed")
class TestDolmaCodeProseCompositionClassifier(TestCase):
```

**Root cause:** The `hf://` scheme is used by the `huggingface_hub` filesystem interface, not by `smart_open`. All other FastText taggers in the codebase (e.g. `quality.py`, `language.py`) use the standard `https://huggingface.co/{org}/{repo}/resolve/main/{file}` pattern that `smart_open` can download correctly.

**Fix:** Use the same HTTPS URL pattern as every other tagger:

```python
MODEL_PATH = "https://huggingface.co/techarb/code-prose-composition/resolve/main/code-comment-prose-model.bin"
```

This also allows the skipped test class in `tests/python/test_code_composition.py` to be re-enabled.