### PR TITLE
fix(runtime): surface descriptive error when 'find' is missing in _make_paths_from_substitution

### DIFF
--- a/python/dolma/core/runtime.py
+++ b/python/dolma/core/runtime.py
@@ -56,11 +56,12 @@ def _make_paths_from_substitution(paths: List[str], find: str, replace: str) -> 
             # nothing past the glob pattern: then we wanna go back up one level in the directory structure
             curr_parts = curr_parts[:-1]
 
-        find_dir_index = curr_parts.index(find)
-
         if not curr_pre_glob.strip():
             raise RuntimeError(f"Path '{curr}' contains a wildcard at the beginning. ")
-        elif find_dir_index < 0:
+
+        try:
+            find_dir_index = curr_parts.index(find)
+        except ValueError:
             raise RuntimeError(f"Path '{curr}' does not contain a '{find}' component.")
 
         dst_parts = [p if i != find_dir_index else replace for i, p in enumerate(curr_parts)]


### PR DESCRIPTION
## Bug

In `_make_paths_from_substitution` (`python/dolma/core/runtime.py`), the branch intended to report a missing path component is unreachable:

```python
find_dir_index = curr_parts.index(find)

if not curr_pre_glob.strip():
    raise RuntimeError(f"Path '{curr}' contains a wildcard at the beginning. ")
elif find_dir_index < 0:
    raise RuntimeError(f"Path '{curr}' does not contain a '{find}' component.")
```

## Root cause

`list.index()` raises `ValueError` when the element is not present — it never returns `-1`. So `find_dir_index < 0` is dead code, and a caller passing a `find` that does not appear in the path gets an uninformative `ValueError: 'X' is not in list` from deep inside the helper, instead of the intended `RuntimeError` naming both the path and the missing component.

The wildcard-prefix check is also ordered after the lookup; when `curr_pre_glob` is empty, `curr_parts` can be empty and `index()` raises before that more specific error can fire.

## Fix

- Move the wildcard-prefix `RuntimeError` above the lookup so it triggers first.
- Wrap `curr_parts.index(find)` in `try/except ValueError` and raise the intended `RuntimeError` from there.

No behavioral change on the happy path; failure paths now produce the message the code already tried to emit.