### PR TITLE
Harden URL blocklist tar extraction

### DIFF
--- a/scripts/download_url_blocklist.py
+++ b/scripts/download_url_blocklist.py
@@ -12,6 +12,7 @@ import tarfile
 from datetime import datetime
 import boto3
 from ftplib import FTP
+from pathlib import Path, PureWindowsPath
 import tempfile
 
 # FTP server details
@@ -36,7 +37,44 @@ def download_and_extract_ftp_file(ftp_url: str, ftp_path: str, extract_to: str) 
 
 def extract_tar_gz(file_path: str, extract_to: str) -> None:
     with tarfile.open(file_path, 'r:gz') as tar:
-        tar.extractall(path=extract_to)
+        for member in tar.getmembers():
+            _extract_tar_member_safely(tar, member, extract_to)
+
+
+def _extract_tar_member_safely(tar: tarfile.TarFile, member: tarfile.TarInfo, extract_to: str) -> None:
+    _validate_tar_member(member, extract_to)
+    try:
+        tar.extract(member, path=extract_to, filter="data")
+    except TypeError as exc:
+        if "filter" not in str(exc):
+            raise
+        tar.extract(member, path=extract_to)
+
+
+def _validate_tar_member(member: tarfile.TarInfo, extract_to: str) -> None:
+    member_path = Path(member.name)
+    windows_path = PureWindowsPath(member.name)
+    extract_root = Path(extract_to).resolve()
+    target_path = (extract_root / member.name).resolve()
+    if (
+        member_path.is_absolute()
+        or windows_path.is_absolute()
+        or windows_path.drive
+        or ".." in member_path.parts
+        or ".." in windows_path.parts
+        or not _is_relative_to(target_path, extract_root)
+    ):
+        raise RuntimeError(f"unsafe archive member: {member.name}")
+    if not (member.isfile() or member.isdir()):
+        raise RuntimeError(f"unsupported archive member: {member.name}")
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
 
 
 def upload_directory_to_s3(directory_path: str, bucket: str, folder: str) -> None:

--- a/tests/python/test_download_url_blocklist.py
+++ b/tests/python/test_download_url_blocklist.py
@@ -1,0 +1,45 @@
+import io
+import importlib.util
+import tarfile
+from pathlib import Path
+
+import pytest
+
+
+def _load_download_url_blocklist_module():
+    script_path = Path(__file__).parents[2] / "scripts" / "download_url_blocklist.py"
+    spec = importlib.util.spec_from_file_location("download_url_blocklist", script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_tar(path: Path, members: list[tuple[str, bytes]]) -> None:
+    with tarfile.open(path, "w:gz") as tar:
+        for name, payload in members:
+            member = tarfile.TarInfo(name)
+            member.size = len(payload)
+            tar.addfile(member, io.BytesIO(payload))
+
+
+def test_extract_tar_gz_extracts_valid_member(tmp_path: Path) -> None:
+    module = _load_download_url_blocklist_module()
+    archive_path = tmp_path / "blacklists.tar.gz"
+    extract_to = tmp_path / "extract"
+    _write_tar(archive_path, [("blacklists/ads/domains", b"example.com\n")])
+
+    module.extract_tar_gz(str(archive_path), str(extract_to))
+
+    assert (extract_to / "blacklists" / "ads" / "domains").read_text() == "example.com\n"
+
+
+@pytest.mark.parametrize("member_name", ["../escaped.txt", "/tmp/escaped.txt", "C:/escaped.txt"])
+def test_extract_tar_gz_rejects_unsafe_member(tmp_path: Path, member_name: str) -> None:
+    module = _load_download_url_blocklist_module()
+    archive_path = tmp_path / "blacklists.tar.gz"
+    extract_to = tmp_path / "extract"
+    _write_tar(archive_path, [(member_name, b"escaped")])
+
+    with pytest.raises(RuntimeError, match="unsafe archive member"):
+        module.extract_tar_gz(str(archive_path), str(extract_to))


### PR DESCRIPTION
## Summary
- validate URL blocklist tar members before extraction
- reject absolute/path-traversal archive entries and unsupported tar member types
- add tests for valid extraction and unsafe POSIX/absolute/Windows-style paths

## Validation
- uv run --no-project --with pytest --with boto3 pytest -q tests/python/test_download_url_blocklist.py
- uv run --no-project --with ruff ruff check scripts/download_url_blocklist.py tests/python/test_download_url_blocklist.py
- python3 -m py_compile scripts/download_url_blocklist.py tests/python/test_download_url_blocklist.py
- git diff --check HEAD~1..HEAD