### PR TITLE
Fix FastPiiRegex doc_frac counting the whole-document span

### DIFF
--- a/python/dolma/taggers/pii.py
+++ b/python/dolma/taggers/pii.py
@@ -271,7 +271,7 @@ class FastPiiRegex(BaseTagger):
 
         try:
             # fraction of words that are PII
-            score = sum(len(s) for s in spans) / len(doc.text)
+            score = sum(len(s) for s in spans if s.type != "doc_count") / len(doc.text)
         except ZeroDivisionError:
             # empty doc
             score = -1.0


### PR DESCRIPTION
## Bug

In `FastPiiRegex.predict` the `doc_frac` attribute ("fraction of words that are PII") is computed *after* the document-level `doc_count` span has already been appended to `spans`:

```python
spans.append(Span(start=0, end=len(doc.text), type="doc_count", score=score))

try:
    # fraction of words that are PII
    score = sum(len(s) for s in spans) / len(doc.text)
```

`Span.__len__` returns `end - start`, and the `doc_count` span spans the entire document (`start=0, end=len(doc.text)`). So its length equals `len(doc.text)` and contributes exactly `1.0` to the sum. `doc_frac` is therefore always inflated by `1.0` and can never be below `1.0`, even for a document with no PII.

## Root cause

`sum(len(s) for s in spans)` includes the just-appended whole-document `doc_count` span, which is a summary/metadata span, not a PII match. The numerator should only count the PII spans.

This mirrors how the rest of the file already separates PII spans from document-level spans: `PiiRegexWithCountV2.predict` and `BasePiiFilter._score` both exclude the document-level span (`if s.type != "doc"`, score computed before the span is appended).

## Fix

Exclude the `doc_count` span from the sum, consistent with the existing `!= "doc"` filtering convention:

```python
score = sum(len(s) for s in spans if s.type != "doc_count") / len(doc.text)
```

With this change `doc_frac` reports the actual PII character fraction (e.g. for a 41-char doc with a 22-char email match: `0.537` instead of `1.537`).