### PR TITLE
Fix infinite loop during tokenization when sequence length exceeds memmap capacity

### DIFF
--- a/python/dolma/tokenizer/memmap_writer.py
+++ b/python/dolma/tokenizer/memmap_writer.py
@@ -74,6 +74,13 @@ class MemmapWriter:
         if self._metadata_file is None:
             raise RuntimeError("Metadata file is not open")
 
+        if len(output.tokens) >= self.max_tokens:
+            raise ValueError(
+                f"Sequence of length {len(output.tokens)} is larger than the maximum memmap capacity "
+                f"of {self.max_tokens} tokens. Please increase the maximum size/capacity of the tokenized "
+                f"files or check if your input documents have extremely long lines/sequences."
+            )
+
         if (len(output.tokens) + self._written_tokens) >= self.max_tokens:
             # return false if the memmap file is full
             return False


### PR DESCRIPTION
### Bug
When running `dolma tokens`, if a single sequence/document has a token count larger than the maximum memmap capacity (`max_tokens`), the tokenization process falls into an infinite loop, creating millions of tiny empty files and filling up the disk.

### Root Cause
In `MemmapWriter.write`, if the incoming sequence is larger than `self.max_tokens`, it will return `False` even on an empty memmap file (since `(len(output.tokens) + self._written_tokens) >= self.max_tokens` is met when `self._written_tokens` is `0`). 

In `executor.py`, `write_many` will fail to write this sequence and return it in `remaining`. The executor loop then closes the current memwriter, opens a new empty one, and tries to write the `remaining` sequence again. Because the sequence still exceeds `max_tokens`, it fails again, creating an infinite loop of memmap file creation.

### Why Fix is Correct
The fix adds a check at the beginning of `MemmapWriter.write` to raise a `ValueError` if the sequence's token count is larger than or equal to `self.max_tokens`. This immediately stops execution with a clear, helpful error message rather than indefinitely creating empty files.