### PR TITLE
Fix fastText label prefix stripping in CodeProseCompositionClassifier

### DIFF
--- a/python/dolma/taggers/code_composition.py
+++ b/python/dolma/taggers/code_composition.py
@@ -51,7 +51,7 @@ class CodeProseCompositionClassifier(BaseFastTextTagger):
         if len(line) > 3:
             labels, probabilities = self.classifier.predict(line, k=-1)
 
-            label = labels[0].lstrip("__label__")
+            label = labels[0].replace("__label__", "")
         return label, probabilities
 
     def predictions(


### PR DESCRIPTION
## Bug

In `CodeProseCompositionClassifier.line_label()`, the fastText label prefix is removed with:

```python
label = labels[0].lstrip("__label__")
```

`str.lstrip(chars)` removes any leading characters that appear in the *set* `chars`, not the literal prefix `"__label__"`. The set here is `{_, l, a, b, e}`, so any predicted label whose name begins with one of those characters is silently corrupted:

| `labels[0]` | `lstrip("__label__")` | expected |
|---|---|---|
| `__label__code` | `code` | `code` |
| `__label__base` | `se` | `base` |
| `__label__assembly` | `ssembly` | `assembly` |
| `__label__latex` | `tex` | `latex` |

The corrupted label is then used as the key in `class_counts` / `prediction_distributions`, so the composition tags emitted for those classes are wrong.

## Fix

Use `replace("__label__", "")`, which removes the prefix literally. This also matches how every other fastText tagger in the codebase strips the prefix:

- `python/dolma/taggers/language.py`: `label.replace("__label__", "")`
- `python/dolma/taggers/quality.py`: `label.replace("__label__", "")`

One-line change; behavior is unchanged for labels that don't begin with one of the affected characters.