### PR TITLE
fix(taggers): use HTTPS URL for code composition model

### DIFF
--- a/python/dolma/taggers/code_composition.py
+++ b/python/dolma/taggers/code_composition.py
@@ -24,7 +24,7 @@ from ..core.registry import TaggerRegistry
 
 @TaggerRegistry.add("code_composition")
 class CodeProseCompositionClassifier(BaseFastTextTagger):
-    MODEL_PATH = "hf://techarb/code-prose-composition/code-comment-prose-model.bin"  # noqa: E501
+    MODEL_PATH = "https://huggingface.co/techarb/code-prose-composition/resolve/main/code-comment-prose-model.bin"  # noqa: E501
 
     def __init__(self):
         super().__init__(model_path=self.MODEL_PATH, model_mode=self.DOCUMENT_LEVEL_TAGGER)


### PR DESCRIPTION
Fixes #268

`CodeProseCompositionClassifier.MODEL_PATH` used an `hf://` URI, but dolma downloads FastText models via `smart_open`, which only handles standard HTTP(S) URLs. Instantiating the tagger failed before any classification ran.

Use the same `https://huggingface.co/.../resolve/main/...` pattern as the other FastText taggers in this repo.

Made with [Cursor](https://cursor.com)