### PR TITLE
fix: avoid divide-by-zero in code composition tagger

### DIFF
--- a/python/dolma/taggers/code_composition.py
+++ b/python/dolma/taggers/code_composition.py
@@ -60,9 +60,13 @@ class CodeProseCompositionClassifier(BaseFastTextTagger):
         class_counts: Dict[str, int],
         prediction_distributions: Dict[str, List[List[float]]],
     ) -> Iterable[Prediction]:
+        total = sum(class_counts.values())
+        if total == 0:
+            return [Prediction(label="boundaries", score=code_prose_boundaries)]
+
         composition = {}
         for label, count in class_counts.items():
-            composition[label] = round((count / sum(class_counts.values())), 2)
+            composition[label] = round(count / total, 2)
 
         out = [Prediction(label="boundaries", score=code_prose_boundaries)]
 


### PR DESCRIPTION
## Summary
- return early when `class_counts` is empty before computing label percentages

Whitespace-only docs never populate `class_counts`, so `sum(class_counts.values())` was 0 and the pct loop crashed.

## Test plan
- [ ] run code composition tagger on an empty/whitespace document and confirm it returns boundary score only


Made with [Cursor](https://cursor.com)