### PR TITLE
fix: RedPajama token count uses findall not split

### DIFF
--- a/python/dolma/taggers/code/code_taggers.py
+++ b/python/dolma/taggers/code/code_taggers.py
@@ -156,7 +156,7 @@ class CodeRedPajamaTaggers(BaseTagger):
         super().__init__()
 
     def _get_num_tokens(self, text: str) -> int:
-        return len(self.whitespace_regex.split(text))
+        return len(self.whitespace_regex.findall(text))
 
     def predict(self, doc: Document) -> DocResult:
         """Main runner."""


### PR DESCRIPTION
## Summary
- `_get_num_tokens` used `split()` → N+1 tokens, inflating `alpha_token_prop`.
- Match tests / RedPajama: `findall()`.

## Test plan
- [ ] `""` → 0 tokens; `"hello"` → 1

Made with [Cursor](https://cursor.com)