### PR TITLE
fix: gopher duplicate-line char fraction denom

### DIFF
--- a/python/dolma/taggers/gopher.py
+++ b/python/dolma/taggers/gopher.py
@@ -194,7 +194,7 @@ def get_attributes(text: str, ignore_empty_lines: bool = False) -> GopherAttribu
         )
         attrs.fraction_of_characters_in_duplicate_lines = sum(
             len(line) * count for line, count in line_counts.items() if count > 1
-        ) / max(character_count, 1)
+        ) / max(attrs.character_count, 1)
     except Exception as e:
         logging.exception(f"Error processing text {e}: {text[:200]}")
 


### PR DESCRIPTION
## Summary
- Duplicate-line char fraction divided by word-char count (no spaces) while numerator uses `len(line)`.
- Could exceed 1; use document `character_count` (`len(text)`).

## Test plan
- [ ] Repeated lines with spaces yield fraction ≤ 1

Made with [Cursor](https://cursor.com)