### PR TITLE
fix: secret span offsets use line number not find()

### DIFF
--- a/python/dolma/taggers/code/code_taggers.py
+++ b/python/dolma/taggers/code/code_taggers.py
@@ -53,7 +53,8 @@ class CodeSecretsTagger(BaseTagger):
             line_number = secret.line_number - 1
             span = secret.secret_value
             span_line = text_lines[line_number]
-            line_start = text.find(span_line)
+            # Index by line number — find() hits the first duplicate line content.
+            line_start = sum(len(l) + 1 for l in text_lines[:line_number])
             start = line_start + span_line.find(span or "")
             end = start + len(span or "")
             assert text[start:end] == span


### PR DESCRIPTION
## Summary
- `CodeSecretsTagger` used `text.find(line)`, which maps duplicate lines to the first occurrence.
- Compute line start from the reported line index.

## Test plan
- [ ] Repeated identical lines: secret on line 2 gets the later offset

Made with [Cursor](https://cursor.com)