### PR TITLE
Improve throughput with gigatoken and batching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "necessary>=0.4.3",
     "charset-normalizer>=3.2.0",
     "zstandard>=0.23.0",
-    "gigatoken>=0.10.0",
+    "gigatoken>=0.10.0,<0.11.0",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "necessary>=0.4.3",
     "charset-normalizer>=3.2.0",
     "zstandard>=0.23.0",
+    "gigatoken>=0.10.0",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/python/dolma/cli/tokenizer.py
+++ b/python/dolma/cli/tokenizer.py
@@ -6,7 +6,7 @@ from dolma.cli.shared import WorkDirConfig, make_workdirs
 from dolma.core.errors import DolmaConfigError
 from dolma.core.loggers import get_logger
 from dolma.core.paths import glob_path
-from dolma.tokenizer import tokenize_in_parallel
+from dolma.tokenizer import TokenizerBackend, tokenize_in_parallel
 
 
 @dataclass
@@ -46,6 +46,15 @@ class TokenizerConfig:
         default=True,
         help="Whether to use the fast tokenizer. If False, it requires the transformers library to be installed.",
     )
+    backend: str = field(
+        default="hf",
+        help=(
+            "Which fast tokenizer implementation to use: 'hf'/'huggingface' (default) or 'gt'/'gigatoken'. "
+            "Gigatoken is substantially faster but newer and less battle-tested; this flag makes it easy to "
+            "switch back to the HuggingFace implementation, or to profile the two against each other. "
+            "Has no effect if --tokenizer.fast is False."
+        ),
+    )
     encode_special_tokens: bool = field(
         default=False,
         help="Whether to encode special tokens in the tokenized output, e.g. splitting '<s>' into '<', 's', '>'.",
@@ -61,6 +70,9 @@ class TokenizerConfig:
 
     def __post__init__(self):
         logger = get_logger(__file__)
+
+        # fail fast on an unknown backend rather than deep inside a worker process
+        TokenizerBackend.parse(self.backend)
 
         if self.eos_token_id is None:
             logger.warning("NO EOS TOKEN PROVIDED. Are you sure this is what you want?")
@@ -237,6 +249,7 @@ class TokenizerCli(BaseCli):
                 debug=parsed_config.debug,
                 sample_ring_prop=parsed_config.sample_ring_prop,
                 use_fast_tokenizer=parsed_config.tokenizer.fast,
+                tokenizer_backend=parsed_config.tokenizer.backend,
                 refresh_tokenizer=parsed_config.tokenizer.refresh,
                 tokenizer_batch_size=parsed_config.tokenizer.batch_size,
                 tokenizer_batch_max_bytes=parsed_config.tokenizer.batch_max_bytes,

--- a/python/dolma/cli/tokenizer.py
+++ b/python/dolma/cli/tokenizer.py
@@ -50,6 +50,14 @@ class TokenizerConfig:
         default=False,
         help="Whether to encode special tokens in the tokenized output, e.g. splitting '<s>' into '<', 's', '>'.",
     )
+    batch_size: int = field(
+        default=64,
+        help="Maximum documents to send to the tokenizer in one batch.",
+    )
+    batch_max_bytes: int = field(
+        default=8 * 1024 * 1024,
+        help="Maximum UTF-8 text bytes to send to the tokenizer in one batch.",
+    )
 
     def __post__init__(self):
         logger = get_logger(__file__)
@@ -230,6 +238,8 @@ class TokenizerCli(BaseCli):
                 sample_ring_prop=parsed_config.sample_ring_prop,
                 use_fast_tokenizer=parsed_config.tokenizer.fast,
                 refresh_tokenizer=parsed_config.tokenizer.refresh,
+                tokenizer_batch_size=parsed_config.tokenizer.batch_size,
+                tokenizer_batch_max_bytes=parsed_config.tokenizer.batch_max_bytes,
                 text_field_name=parsed_config.fields.text_field_name,
                 text_field_type=parsed_config.fields.text_field_type,
                 id_field_name=parsed_config.fields.id_field_name,

--- a/python/dolma/tokenizer/__init__.py
+++ b/python/dolma/tokenizer/__init__.py
@@ -1,9 +1,10 @@
 from .data_types import TokenizerOutput
 from .executor import tokenize_in_parallel
-from .tokenizer import Tokenizer, tokenize_file
+from .tokenizer import Tokenizer, TokenizerBackend, tokenize_file
 
 __all__ = [
     "Tokenizer",
+    "TokenizerBackend",
     "tokenize_file",
     "tokenize_in_parallel",
     "TokenizerOutput",

--- a/python/dolma/tokenizer/executor.py
+++ b/python/dolma/tokenizer/executor.py
@@ -78,8 +78,9 @@ class MemMapParallelWriter(BaseParallelProcessor):
         tokenizer_batch_size = kwargs.pop("tokenizer_batch_size", None) or 64
         tokenizer_batch_max_bytes = kwargs.pop("tokenizer_batch_max_bytes", None) or 8 * 1024 * 1024
 
-        # Controls whether to use the fast tokenizer or not
+        # Controls whether to use the fast tokenizer or not, and which fast backend to use
         tokenizer_kwargs["use_fast"] = bool(kwargs.pop("use_fast_tokenizer", True))
+        tokenizer_kwargs["backend"] = kwargs.pop("tokenizer_backend", None) or "hf"
 
         tokenizer_kwargs["pad_token_id"] = kwargs.pop("pad_token_id", None)
         if tokenizer_kwargs["pad_token_id"] is None:
@@ -362,6 +363,7 @@ def tokenize_in_parallel(
     tokenizer_batch_size: int = 64,
     tokenizer_batch_max_bytes: int = 8 * 1024 * 1024,
     use_fast_tokenizer: bool = True,
+    tokenizer_backend: str = "hf",
     text_field_name: str = "text",
     text_field_type: str = "str",
     id_field_name: Optional[str] = "id",
@@ -397,6 +399,8 @@ def tokenize_in_parallel(
         tokenizer_batch_size (int, optional): Maximum documents in each tokenizer batch. Defaults to 64.
         tokenizer_batch_max_bytes (int, optional): Maximum UTF-8 bytes in each tokenizer batch. Defaults to 8 MiB.
         use_fast_tokenizer (bool, optional): Whether to use the fast tokenizer. Defaults to True.
+        tokenizer_backend (str, optional): Which fast tokenizer implementation to use: "hf"/"huggingface"
+            or "gt"/"gigatoken". Ignored if use_fast_tokenizer is False. Defaults to "hf".
         text_field_name (str, optional): Name of the text field in the input files. Defaults to "text".
         text_field_type (str, optional): Type of the text field in the input files. Defaults to "str".
         id_field_name (str, optional): Name of the id field in the input files. Defaults to "id". Set to None if
@@ -414,6 +418,7 @@ def tokenize_in_parallel(
         eos_token_id=eos_token_id,
         pad_token_id=pad_token_id,
         use_fast=use_fast_tokenizer,
+        backend=tokenizer_backend,
     )
     if tokenizer.dtype != np.dtype(dtype):
         raise TypeError(
@@ -452,6 +457,7 @@ def tokenize_in_parallel(
         tokenizer_name_or_path=tokenizer_name_or_path,
         sample_ring_prop=sample_ring_prop,
         use_fast_tokenizer=use_fast_tokenizer,
+        tokenizer_backend=tokenizer_backend,
         refresh_tokenizer=refresh_tokenizer,
         tokenizer_batch_size=tokenizer_batch_size,
         tokenizer_batch_max_bytes=tokenizer_batch_max_bytes,

--- a/python/dolma/tokenizer/executor.py
+++ b/python/dolma/tokenizer/executor.py
@@ -75,6 +75,8 @@ class MemMapParallelWriter(BaseParallelProcessor):
             )
         # Controls whether to refresh the tokenizer at the end of each batch
         refresh_tokenizer = kwargs.pop("refresh_tokenizer", None) or -1
+        tokenizer_batch_size = kwargs.pop("tokenizer_batch_size", None) or 64
+        tokenizer_batch_max_bytes = kwargs.pop("tokenizer_batch_max_bytes", None) or 8 * 1024 * 1024
 
         # Controls whether to use the fast tokenizer or not
         tokenizer_kwargs["use_fast"] = bool(kwargs.pop("use_fast_tokenizer", True))
@@ -120,6 +122,8 @@ class MemMapParallelWriter(BaseParallelProcessor):
                     tokenizer_name_or_path=tokenizer_name_or_path,
                     path=path,
                     refresh_tokenizer_every=refresh_tokenizer,
+                    batch_size=tokenizer_batch_size,
+                    batch_max_bytes=tokenizer_batch_max_bytes,
                     **tokenizer_kwargs,
                 )
             )
@@ -157,6 +161,8 @@ class MemMapParallelWriter(BaseParallelProcessor):
                                     tokenizer_name_or_path=tokenizer_name_or_path,
                                     path=path,
                                     refresh_tokenizer_every=refresh_tokenizer,
+                                    batch_size=tokenizer_batch_size,
+                                    batch_max_bytes=tokenizer_batch_max_bytes,
                                     **tokenizer_kwargs,
                                 )
                             )
@@ -198,6 +204,8 @@ class MemMapParallelWriter(BaseParallelProcessor):
                                     tokenizer_name_or_path=tokenizer_name_or_path,
                                     path=path,
                                     refresh_tokenizer_every=refresh_tokenizer,
+                                    batch_size=tokenizer_batch_size,
+                                    batch_max_bytes=tokenizer_batch_max_bytes,
                                     **tokenizer_kwargs,
                                 )
                             )
@@ -351,6 +359,8 @@ def tokenize_in_parallel(
     debug: bool = False,
     sample_ring_prop: bool = False,
     refresh_tokenizer: int = 0,
+    tokenizer_batch_size: int = 64,
+    tokenizer_batch_max_bytes: int = 8 * 1024 * 1024,
     use_fast_tokenizer: bool = True,
     text_field_name: str = "text",
     text_field_type: str = "str",
@@ -384,6 +394,8 @@ def tokenize_in_parallel(
             of files. Otherwise, it will go round-robin. Defaults to False.
         refresh_tokenizer (int, optional): Number of batches after which to refresh the tokenizer.
             Defaults to 0, which means the tokenizer will not be refreshed.
+        tokenizer_batch_size (int, optional): Maximum documents in each tokenizer batch. Defaults to 64.
+        tokenizer_batch_max_bytes (int, optional): Maximum UTF-8 bytes in each tokenizer batch. Defaults to 8 MiB.
         use_fast_tokenizer (bool, optional): Whether to use the fast tokenizer. Defaults to True.
         text_field_name (str, optional): Name of the text field in the input files. Defaults to "text".
         text_field_type (str, optional): Type of the text field in the input files. Defaults to "str".
@@ -441,6 +453,8 @@ def tokenize_in_parallel(
         sample_ring_prop=sample_ring_prop,
         use_fast_tokenizer=use_fast_tokenizer,
         refresh_tokenizer=refresh_tokenizer,
+        tokenizer_batch_size=tokenizer_batch_size,
+        tokenizer_batch_max_bytes=tokenizer_batch_max_bytes,
         text_field_name=text_field_name,
         text_field_type=text_field_type,
         id_field_name=id_field_name,

--- a/python/dolma/tokenizer/tokenizer.py
+++ b/python/dolma/tokenizer/tokenizer.py
@@ -312,7 +312,7 @@ class Tokenizer:
             encoded_slice_iter = (
                 # the slicing operation is required if we have added a space in front of each paragraph
                 # during the `split_into_paragraphs` method.
-                encoded[pos][1:] if (self.tokenizer_has_prefix and pos > 0) else encoded[pos]
+                encoded[pos][1:] if (self.tokenizer_has_prefix and pos > start) else encoded[pos]
                 for pos in range(start, end)
             )
             merged.append(list(chain.from_iterable(encoded_slice_iter)))
@@ -454,11 +454,18 @@ def tokenize_file(
     id_field_name: Optional[str] = "id",
     id_field_type: type = str,
     refresh_tokenizer_every: int = 0,
+    batch_size: int = 64,
+    batch_max_bytes: int = 8 * 1024 * 1024,
     **tokenizer_kwargs,
 ) -> Generator[TokenizerOutput, None, None]:
     """Tokenize a file of documents using the provided tokenizer; file is expected to be a gzipped JSON lines
     file, each containing a field named `text`.
     """
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+    if batch_max_bytes <= 0:
+        raise ValueError("batch_max_bytes must be positive")
+
     tokenizer = make_tokenizer(tokenizer_name_or_path, **tokenizer_kwargs)
     dtype = deepcopy(tokenizer.dtype)
 
@@ -480,6 +487,43 @@ def tokenize_file(
     )
     decoder = msgspec.json.Decoder(spec)
     force_refresh = False
+    batch: list[tuple[str, str, int]] = []
+    batch_bytes = 0
+
+    def flush_batch() -> list[TokenizerOutput]:
+        """Tokenize the pending records while retaining per-record failure handling."""
+        nonlocal batch, batch_bytes
+        if not batch:
+            return []
+
+        pending = batch
+        batch = []
+        batch_bytes = 0
+        texts = [text for _, text, _ in pending]
+        try:
+            token_batches = tokenizer.encode_batch(texts, add_special_tokens=True)
+        except Exception as ex:
+            # Maintain the old behavior if one input makes a batch fail: log
+            # and skip only failing records, not every valid record in it.
+            logger.warning("Error tokenizing batch from %s: %s", path, ex)
+            token_batches = []
+            for row_id, text, loc in pending:
+                try:
+                    token_batches.append(tokenizer.encode(text, add_special_tokens=True))
+                except Exception as record_ex:
+                    logger.warning("Error processing line %s:%d: %s", path, loc, record_ex)
+                    token_batches.append(None)  # type: ignore[arg-type]
+
+        outputs = []
+        for (row_id, _, loc), tokens in zip(pending, token_batches):
+            if tokens is None:
+                continue
+            if refresh_tokenizer_every:
+                # Extra copy to prevent memory leaks, matching the previous
+                # per-document tokenization path.
+                tokens = np.array(tokens, dtype=dtype)
+            outputs.append(TokenizerOutput.from_tokens(id=row_id, src=path, loc=loc, tokens=tokens))  # pyright: ignore
+        return outputs
 
     try:
         with smart_open.open(path, mode="rt") as input_stream:
@@ -494,16 +538,20 @@ def tokenize_file(
                         # skip empty docs
                         continue
 
-                    # the actual tokenization happens here
-                    tokens = tokenizer.encode(text, add_special_tokens=True)
+                    text_bytes = len(text.encode("utf-8"))
+                    if batch and (len(batch) >= batch_size or batch_bytes + text_bytes > batch_max_bytes):
+                        yield from flush_batch()
 
-                    if refresh_tokenizer_every:
-                        # extra copy to prevent memory leaks
-                        tokens = np.array(tokens, dtype=dtype)
+                    batch.append((row_id, text, i))
+                    batch_bytes += text_bytes
 
-                    yield TokenizerOutput.from_tokens(id=row_id, src=path, loc=i, tokens=tokens)  # pyright: ignore
+                    # An oversized document is retained and emitted as a
+                    # one-item batch instead of being dropped or split.
+                    refresh_due = (refresh_tokenizer_every > 0 and i % refresh_tokenizer_every == 0) or force_refresh
+                    if len(batch) >= batch_size or batch_bytes >= batch_max_bytes or refresh_due:
+                        yield from flush_batch()
 
-                    if (refresh_tokenizer_every > 0 and i % refresh_tokenizer_every == 0) or force_refresh:
+                    if refresh_due:
                         # to prevent memory leaks, we refresh the tokenizer every so often
                         del tokenizer
                         gc.collect()
@@ -516,8 +564,12 @@ def tokenize_file(
                     # in case of failure, we log the error and continue
                     # We refresh the tokenizer to prevent memory leaks from affecting the rest of the processing
                     logger.warning("Error processing line %s:%d: %s", path, i, ex)
+                    # Do not let a malformed record strand preceding valid
+                    # documents in a partially-filled batch.
+                    yield from flush_batch()
                     force_refresh = True
                     continue
+            yield from flush_batch()
     except Exception as ex:
         # more catastrophic error, so we log the error and re-raise
         logger.error("Error processing file %s", path, exc_info=ex)

--- a/python/dolma/tokenizer/tokenizer.py
+++ b/python/dolma/tokenizer/tokenizer.py
@@ -71,6 +71,36 @@ class TruncationDirection(StrEnum):
     left = "left"
 
 
+class TokenizerBackend(StrEnum):
+    """Which library implements the fast tokenization path.
+
+    ``huggingface`` uses the original ``tokenizers`` Rust bindings; ``gigatoken`` uses the
+    newer, faster ``gigatoken`` library. Has no effect when ``use_fast=False``, since that
+    always uses the slow ``transformers`` tokenizer.
+    """
+
+    huggingface = "hf"
+    gigatoken = "gt"
+
+    @classmethod
+    def parse(cls, value: "str | TokenizerBackend") -> "TokenizerBackend":
+        if isinstance(value, TokenizerBackend):
+            return value
+
+        aliases = {
+            "hf": cls.huggingface,
+            "huggingface": cls.huggingface,
+            "gt": cls.gigatoken,
+            "gigatoken": cls.gigatoken,
+        }
+        normalized = str(value).strip().lower()
+        if normalized not in aliases:
+            raise DolmaConfigError(
+                f"Unknown tokenizer backend '{value}'; expected one of: hf, huggingface, gt, gigatoken."
+            )
+        return aliases[normalized]
+
+
 class Tokenizer:
     """
     A :class:`Tokenizer` is a light-weight wrapper around a HuggingFace :class:`tokenizers.Tokenizer`.
@@ -100,7 +130,14 @@ class Tokenizer:
         self.pad_token_id = pad_token_id
         # Gigatoken uses the HuggingFace tokenizer.json format directly, but
         # returns token IDs rather than HuggingFace Encoding objects.
-        self.is_fast = isinstance(self.base_tokenizer, gt.Tokenizer)
+        if isinstance(self.base_tokenizer, gt.Tokenizer):
+            self.backend: Optional[TokenizerBackend] = TokenizerBackend.gigatoken
+        elif isinstance(self.base_tokenizer, HFTokenizer):
+            self.backend = TokenizerBackend.huggingface
+        else:
+            # slow, transformers-backed tokenizer
+            self.backend = None
+        self.is_fast = self.backend is not None
 
         if self.pad_token_id is None:
             logger.warning("No pad token ID provided; using EOS token ID %s.", eos_token_id)
@@ -127,6 +164,8 @@ class Tokenizer:
     @encode_special_tokens.setter
     def encode_special_tokens(self, value: bool):
         self._encode_special_tokens = value
+        if self.backend == TokenizerBackend.huggingface:
+            self.base_tokenizer.encode_special_tokens = value  # pyright: ignore
 
     @cached_property
     def tokenizer_has_prefix(self) -> bool:
@@ -164,18 +203,24 @@ class Tokenizer:
         return HFTokenizer.from_str(json.dumps(self.config))
 
     def get_base_tokenizer_config(self) -> dict:
-        if self.is_fast:
+        if self.backend == TokenizerBackend.gigatoken:
             return self.base_tokenizer._hf_config()
 
+        # Rust HuggingFace tokenizers don't have a way to get the full configuration through Python bindings,
+        # so we hack around it by saving the tokenizer to a temporary file and reading the config.
         with TemporaryDirectory() as temp_dir:
-            self.save(temp_dir)
-            with open(f"{temp_dir}/tokenizer_config.json", mode="r", encoding="utf-8") as f:
+            config_path = f"{temp_dir}/tokenizer"
+            self.save(config_path)
+            if not self.is_fast:
+                config_path += "/tokenizer_config.json"
+
+            with open(config_path, mode="r", encoding="utf-8") as f:
                 return json.load(f)
 
     @property
     def vocab_size(self) -> int:
-        if self.is_fast:
-            return self.base_tokenizer.vocab_size
+        if self.backend == TokenizerBackend.huggingface:
+            return self.base_tokenizer.get_vocab_size()
         return self.base_tokenizer.vocab_size  # pyright: ignore
 
     @classmethod
@@ -198,16 +243,29 @@ class Tokenizer:
         return tokenizer
 
     @classmethod
-    def from_pretrained(cls, identifier: str, use_fast: bool = True, **kwargs) -> "Tokenizer":
+    def from_pretrained(
+        cls,
+        identifier: str,
+        use_fast: bool = True,
+        backend: "str | TokenizerBackend" = TokenizerBackend.huggingface,
+        **kwargs,
+    ) -> "Tokenizer":
         """
         Initialize a tokenizer from a pretrained tokenizer on the HuggingFace Hub.
 
         :param identifier: The identifier of a model on the Hub that contains a
             ``tokenizer.json`` file.
+        :param use_fast: Whether to use a fast (Rust-backed) tokenizer. If False, ``backend`` is
+            ignored and the slow ``transformers`` tokenizer is used instead.
+        :param backend: Which fast tokenizer implementation to use: ``"hf"``/``"huggingface"``
+            (default) or ``"gt"``/``"gigatoken"``. Only relevant when ``use_fast`` is True.
         :param kwargs: Other key word arguments passed to :class:`Tokenizer`.
         """
         if use_fast:
-            base_tokenizer = gt.Tokenizer(identifier)
+            if TokenizerBackend.parse(backend) == TokenizerBackend.gigatoken:
+                base_tokenizer = gt.Tokenizer(identifier)
+            else:
+                base_tokenizer = HFTokenizer.from_pretrained(identifier)
         else:
             assert TRANSFORMERS_AVAILABLE, "Cannot use slow tokenizers without transformers library installed."
             base_tokenizer = AutoTokenizer.from_pretrained(identifier, use_fast=False)
@@ -217,9 +275,11 @@ class Tokenizer:
 
     def save(self, filename: PathOrStr) -> None:
         """Save the tokenizer to a file."""
-        if self.is_fast:
+        if self.backend == TokenizerBackend.gigatoken:
             with open(filename, mode="w", encoding="utf-8") as f:
                 json.dump(self.base_tokenizer._hf_config(), f)
+        elif self.backend == TokenizerBackend.huggingface:
+            self.base_tokenizer.save(filename)  # pyright: ignore
         else:
             assert TRANSFORMERS_AVAILABLE, "Cannot save slow tokenizers without transformers library installed."
             self.base_tokenizer.save_pretrained(filename)  # pyright: ignore
@@ -234,17 +294,31 @@ class Tokenizer:
             logger.warning("pad_token_id mismatch: %s != %s", tokenizer.pad_token_id, id_)  # pyright: ignore
 
     @classmethod
-    def from_file(cls, filename: PathOrStr, use_fast: bool = True, **kwargs) -> "Tokenizer":
+    def from_file(
+        cls,
+        filename: PathOrStr,
+        use_fast: bool = True,
+        backend: "str | TokenizerBackend" = TokenizerBackend.huggingface,
+        **kwargs,
+    ) -> "Tokenizer":
         """
         Initialize a tokenizer from a file.
 
-        You can create those files with ``BaseTokenizer.save()``.
+        You can create those files with :meth:`Tokenizer.save`.
 
         :param filename: The name of a file containing a tokenizer specification.
+        :param use_fast: Whether to use a fast (Rust-backed) tokenizer. If False, ``backend`` is
+            ignored and the slow ``transformers`` tokenizer is used instead.
+        :param backend: Which fast tokenizer implementation to use: ``"hf"``/``"huggingface"``
+            (default) or ``"gt"``/``"gigatoken"``. Only relevant when ``use_fast`` is True.
         :param kwargs: Other key word arguments passed to :class:`Tokenizer`.
         """
         if use_fast:
-            base_tokenizer = gt.Tokenizer(filename)
+            if TokenizerBackend.parse(backend) == TokenizerBackend.gigatoken:
+                base_tokenizer = gt.Tokenizer(filename)
+            else:
+                # unlike gigatoken, the tokenizers Rust bindings require a str, not a PathLike
+                base_tokenizer = HFTokenizer.from_file(str(filename))
         else:
             assert TRANSFORMERS_AVAILABLE, "Cannot use slow tokenizers without transformers library installed."
             base_tokenizer = AutoTokenizer.from_pretrained(filename, use_fast=False)
@@ -357,6 +431,10 @@ class Tokenizer:
         return all_input_ids
 
     def _encode_fast_batch(self, inputs: List[str]) -> List[List[int]]:
+        if self.backend == TokenizerBackend.huggingface:
+            fast_seq = self.base_tokenizer.encode_batch(inputs, add_special_tokens=False)  # pyright: ignore
+            return [e.ids for e in fast_seq]
+
         # Gigatoken recognizes added special tokens by default, which matches
         # HuggingFace when ``encode_special_tokens`` is false. The opt-in flag
         # instead encodes the special-token text as ordinary text.
@@ -370,11 +448,11 @@ class Tokenizer:
         """
         Decode a list of token IDs to a string.
         """
-        if self.is_fast:
+        if self.backend == TokenizerBackend.gigatoken:
             if skip_special_tokens:
                 token_ids = [token_id for token_id in token_ids if token_id not in self.special_token_ids]
             return self.base_tokenizer.decode(token_ids).decode("utf-8", errors="replace")
-        return self.base_tokenizer.decode(token_ids, skip_special_tokens=skip_special_tokens)
+        return self.base_tokenizer.decode(token_ids, skip_special_tokens=skip_special_tokens)  # pyright: ignore
 
 
 def make_tokenizer(

--- a/python/dolma/tokenizer/tokenizer.py
+++ b/python/dolma/tokenizer/tokenizer.py
@@ -602,7 +602,9 @@ def tokenize_file(
                 # Extra copy to prevent memory leaks, matching the previous
                 # per-document tokenization path.
                 tokens = np.array(tokens, dtype=dtype)
-            outputs.append(TokenizerOutput.from_tokens(id=row_id, src=path, loc=loc, tokens=tokens))  # pyright: ignore
+            outputs.append(
+                TokenizerOutput.from_tokens(id=row_id, src=path, loc=loc, tokens=tokens)
+            )  # pyright: ignore
         return outputs
 
     try:
@@ -627,7 +629,9 @@ def tokenize_file(
 
                     # An oversized document is retained and emitted as a
                     # one-item batch instead of being dropped or split.
-                    refresh_due = (refresh_tokenizer_every > 0 and i % refresh_tokenizer_every == 0) or force_refresh
+                    refresh_due = (
+                        refresh_tokenizer_every > 0 and i % refresh_tokenizer_every == 0
+                    ) or force_refresh
                     if len(batch) >= batch_size or batch_bytes >= batch_max_bytes or refresh_due:
                         yield from flush_batch()
 

--- a/python/dolma/tokenizer/tokenizer.py
+++ b/python/dolma/tokenizer/tokenizer.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     Generator,
     List,
@@ -26,12 +27,13 @@ from typing import (
     cast,
 )
 
+import gigatoken as gt
 import msgspec
 import numpy as np
 import smart_open
 from necessary import necessary
 from omegaconf import DictConfig
-from tokenizers import Tokenizer as BaseTokenizer
+from tokenizers import Tokenizer as HFTokenizer
 
 from ..core.errors import DolmaConfigError
 from ..core.loggers import get_logger
@@ -83,7 +85,7 @@ class Tokenizer:
 
     def __init__(
         self,
-        base_tokenizer: BaseTokenizer,
+        base_tokenizer: Any,
         bos_token_id: Optional[int] = None,
         eos_token_id: Optional[int] = None,
         pad_token_id: Optional[int] = None,
@@ -96,7 +98,9 @@ class Tokenizer:
         self.bos_token_id = bos_token_id
         self.eos_token_id = eos_token_id
         self.pad_token_id = pad_token_id
-        self.is_fast = isinstance(self.base_tokenizer, BaseTokenizer)
+        # Gigatoken uses the HuggingFace tokenizer.json format directly, but
+        # returns token IDs rather than HuggingFace Encoding objects.
+        self.is_fast = isinstance(self.base_tokenizer, gt.Tokenizer)
 
         if self.pad_token_id is None:
             logger.warning("No pad token ID provided; using EOS token ID %s.", eos_token_id)
@@ -107,6 +111,12 @@ class Tokenizer:
         self.segment_before_tokenization = segment_before_tokenization
 
         self.config = self.get_base_tokenizer_config()
+        self.special_token_ids = {
+            token["id"] for token in self.config.get("added_tokens", []) if token.get("special", False)
+        }
+        self.special_tokens = tuple(
+            token["content"] for token in self.config.get("added_tokens", []) if token.get("special", False)
+        )
         self.dtype = np.min_scalar_type(self.vocab_size - 1)
         self.encode_special_tokens = encode_special_tokens
 
@@ -117,8 +127,6 @@ class Tokenizer:
     @encode_special_tokens.setter
     def encode_special_tokens(self, value: bool):
         self._encode_special_tokens = value
-        if self.is_fast:
-            self.base_tokenizer.encode_special_tokens = value  # pyright: ignore
 
     @cached_property
     def tokenizer_has_prefix(self) -> bool:
@@ -150,27 +158,25 @@ class Tokenizer:
         # all checks above failed, so we return False
         return False
 
+    @cached_property
+    def _hf_special_token_fallback(self) -> HFTokenizer:
+        """Preserve HF's opt-out behavior for recognized special-token text."""
+        return HFTokenizer.from_str(json.dumps(self.config))
+
     def get_base_tokenizer_config(self) -> dict:
-        # Rust HuggingFace tokenizers don't have a way to get the full configuration through Python bindings,
-        # so we hack around it by saving the tokenizer to a temporary file and reading the config.
+        if self.is_fast:
+            return self.base_tokenizer._hf_config()
 
         with TemporaryDirectory() as temp_dir:
-            config_path = f"{temp_dir}/tokenizer"
-            self.save(config_path)
-            if not self.is_fast:
-                config_path += "/tokenizer_config.json"
-
-            with open(config_path, mode="r", encoding="utf-8") as f:
-                config = json.load(f)
-
-        return config
+            self.save(temp_dir)
+            with open(f"{temp_dir}/tokenizer_config.json", mode="r", encoding="utf-8") as f:
+                return json.load(f)
 
     @property
     def vocab_size(self) -> int:
         if self.is_fast:
-            return self.base_tokenizer.get_vocab_size()
-        else:
-            return self.base_tokenizer.vocab_size  # pyright: ignore
+            return self.base_tokenizer.vocab_size
+        return self.base_tokenizer.vocab_size  # pyright: ignore
 
     @classmethod
     def from_train_config(cls, config: DictConfig) -> "Tokenizer":
@@ -201,7 +207,7 @@ class Tokenizer:
         :param kwargs: Other key word arguments passed to :class:`Tokenizer`.
         """
         if use_fast:
-            base_tokenizer = BaseTokenizer.from_pretrained(identifier)
+            base_tokenizer = gt.Tokenizer(identifier)
         else:
             assert TRANSFORMERS_AVAILABLE, "Cannot use slow tokenizers without transformers library installed."
             base_tokenizer = AutoTokenizer.from_pretrained(identifier, use_fast=False)
@@ -212,7 +218,8 @@ class Tokenizer:
     def save(self, filename: PathOrStr) -> None:
         """Save the tokenizer to a file."""
         if self.is_fast:
-            self.base_tokenizer.save(filename)
+            with open(filename, mode="w", encoding="utf-8") as f:
+                json.dump(self.base_tokenizer._hf_config(), f)
         else:
             assert TRANSFORMERS_AVAILABLE, "Cannot save slow tokenizers without transformers library installed."
             self.base_tokenizer.save_pretrained(filename)  # pyright: ignore
@@ -237,7 +244,7 @@ class Tokenizer:
         :param kwargs: Other key word arguments passed to :class:`Tokenizer`.
         """
         if use_fast:
-            base_tokenizer = BaseTokenizer.from_file(filename)
+            base_tokenizer = gt.Tokenizer(filename)
         else:
             assert TRANSFORMERS_AVAILABLE, "Cannot use slow tokenizers without transformers library installed."
             base_tokenizer = AutoTokenizer.from_pretrained(filename, use_fast=False)
@@ -326,8 +333,7 @@ class Tokenizer:
         if self.segment_before_tokenization:
             sliced_inputs, slice_locs = self.split_into_paragraphs(inputs)
             if self.is_fast:
-                fast_seq = self.base_tokenizer.encode_batch(sliced_inputs, add_special_tokens=False)
-                slice_encoding = [e.ids for e in fast_seq]
+                slice_encoding = self._encode_fast_batch(sliced_inputs)
             else:
                 slow_seq = self.base_tokenizer(sliced_inputs, add_special_tokens=False)  # pyright: ignore
                 slice_encoding = slow_seq.input_ids
@@ -335,8 +341,7 @@ class Tokenizer:
             batch_encoding = self.merge_paragraphs(slice_encoding, slice_locs)
         else:
             if self.is_fast:
-                fast_batch = self.base_tokenizer.encode_batch(inputs, add_special_tokens=False)
-                batch_encoding = [e.ids for e in fast_batch]
+                batch_encoding = self._encode_fast_batch(inputs)
             else:
                 slow_batch = self.base_tokenizer(
                     inputs, add_special_tokens=False, split_special_tokens=self.encode_special_tokens
@@ -351,10 +356,24 @@ class Tokenizer:
             all_input_ids.append(input_ids)
         return all_input_ids
 
+    def _encode_fast_batch(self, inputs: List[str]) -> List[List[int]]:
+        # Gigatoken recognizes added special tokens by default, which matches
+        # HuggingFace when ``encode_special_tokens`` is false. The opt-in flag
+        # instead encodes the special-token text as ordinary text.
+        if self.encode_special_tokens and any(token in text for text in inputs for token in self.special_tokens):
+            fallback = self._hf_special_token_fallback
+            fallback.encode_special_tokens = True
+            return [encoding.ids for encoding in fallback.encode_batch(inputs)]
+        return self.base_tokenizer.encode_batch(inputs).to_list()
+
     def decode(self, token_ids: List[int], skip_special_tokens: bool = True) -> str:
         """
         Decode a list of token IDs to a string.
         """
+        if self.is_fast:
+            if skip_special_tokens:
+                token_ids = [token_id for token_id in token_ids if token_id not in self.special_token_ids]
+            return self.base_tokenizer.decode(token_ids).decode("utf-8", errors="replace")
         return self.base_tokenizer.decode(token_ids, skip_special_tokens=skip_special_tokens)
 
 

--- a/python/dolma/tokenizer/tokenizer.py
+++ b/python/dolma/tokenizer/tokenizer.py
@@ -500,8 +500,9 @@ def tokenize_file(
         batch = []
         batch_bytes = 0
         texts = [text for _, text, _ in pending]
+        token_batches: list[list[int] | None]
         try:
-            token_batches = tokenizer.encode_batch(texts, add_special_tokens=True)
+            token_batches = list(tokenizer.encode_batch(texts, add_special_tokens=True))
         except Exception as ex:
             # Maintain the old behavior if one input makes a batch fail: log
             # and skip only failing records, not every valid record in it.
@@ -512,12 +513,13 @@ def tokenize_file(
                     token_batches.append(tokenizer.encode(text, add_special_tokens=True))
                 except Exception as record_ex:
                     logger.warning("Error processing line %s:%d: %s", path, loc, record_ex)
-                    token_batches.append(None)  # type: ignore[arg-type]
+                    token_batches.append(None)
 
         outputs = []
-        for (row_id, _, loc), tokens in zip(pending, token_batches):
-            if tokens is None:
+        for (row_id, _, loc), maybe_tokens in zip(pending, token_batches):
+            if maybe_tokens is None:
                 continue
+            tokens = maybe_tokens
             if refresh_tokenizer_every:
                 # Extra copy to prevent memory leaks, matching the previous
                 # per-document tokenization path.

--- a/scripts/benchmark_tokenizer_batch.py
+++ b/scripts/benchmark_tokenizer_batch.py
@@ -1,0 +1,42 @@
+"""Compare singleton and batched Dolma tokenizer throughput.
+
+Usage:
+    uv run python scripts/benchmark_tokenizer_batch.py tokenizer.json documents.txt
+"""
+
+import argparse
+import time
+from pathlib import Path
+
+from dolma.tokenizer import Tokenizer
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tokenizer", type=Path, help="HuggingFace-compatible tokenizer.json")
+    parser.add_argument("documents", type=Path, help="UTF-8 file containing one document per line")
+    parser.add_argument("--batch-size", type=int, default=64)
+    args = parser.parse_args()
+
+    documents = [line.strip() for line in args.documents.read_text(encoding="utf-8").splitlines() if line.strip()]
+    tokenizer = Tokenizer.from_file(args.tokenizer)
+
+    def run_singleton() -> int:
+        return sum(len(tokenizer.encode(text, add_special_tokens=False)) for text in documents)
+
+    def run_batched() -> int:
+        return sum(
+            len(ids)
+            for start in range(0, len(documents), args.batch_size)
+            for ids in tokenizer.encode_batch(documents[start : start + args.batch_size], add_special_tokens=False)
+        )
+
+    for label, run in (("singleton", run_singleton), ("batched", run_batched)):
+        started = time.perf_counter()
+        tokens = run()
+        elapsed = time.perf_counter() - started
+        print(f"{label:9} {tokens / elapsed:,.0f} tokens/s ({tokens:,} tokens in {elapsed:.3f}s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_tokenizer_batch.py
+++ b/scripts/benchmark_tokenizer_batch.py
@@ -2,13 +2,14 @@
 
 Usage:
     uv run python scripts/benchmark_tokenizer_batch.py tokenizer.json documents.txt
+    uv run python scripts/benchmark_tokenizer_batch.py tokenizer.json documents.txt --backend gt
 """
 
 import argparse
 import time
 from pathlib import Path
 
-from dolma.tokenizer import Tokenizer
+from dolma.tokenizer import Tokenizer, TokenizerBackend
 
 
 def main() -> None:
@@ -16,10 +17,16 @@ def main() -> None:
     parser.add_argument("tokenizer", type=Path, help="HuggingFace-compatible tokenizer.json")
     parser.add_argument("documents", type=Path, help="UTF-8 file containing one document per line")
     parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument(
+        "--backend",
+        type=TokenizerBackend.parse,
+        default=TokenizerBackend.huggingface,
+        help="Fast tokenizer backend to benchmark: hf/huggingface (default) or gt/gigatoken.",
+    )
     args = parser.parse_args()
 
     documents = [line.strip() for line in args.documents.read_text(encoding="utf-8").splitlines() if line.strip()]
-    tokenizer = Tokenizer.from_file(args.tokenizer)
+    tokenizer = Tokenizer.from_file(args.tokenizer, backend=args.backend)
 
     def run_singleton() -> int:
         return sum(len(tokenizer.encode(text, add_special_tokens=False)) for text in documents)

--- a/tests/python/test_tokenizer.py
+++ b/tests/python/test_tokenizer.py
@@ -5,7 +5,7 @@ import shutil
 from contextlib import ExitStack
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory, mkdtemp
-from typing import Optional
+from typing import Any, Dict, Optional
 from unittest import TestCase
 
 import numpy
@@ -19,25 +19,25 @@ from dolma.tokenizer import Tokenizer, tokenize_file, tokenize_in_parallel
 TEST_DIR = Path(__file__).parent.parent.resolve()
 
 
-LLAMA_TOKENIZER = {
+LLAMA_TOKENIZER: Dict[str, Any] = {
     "filename": f"{TEST_DIR}/data/tokenizer/llama-test-tokenizer.json",
     "bos_token_id": 1,
     "eos_token_id": 2,
     "pad_token_id": None,
 }
-GPT_NEO_TOKENIZER = {
+GPT_NEO_TOKENIZER: Dict[str, Any] = {
     "filename": f"{TEST_DIR}/data/tokenizer/gpt-neo-test-tokenizer.json",
     "bos_token_id": None,
     "eos_token_id": 50279,
     "pad_token_id": 1,
 }
-LLAMA3_TOKENIZER = {
+LLAMA3_TOKENIZER: Dict[str, Any] = {
     "filename": f"{TEST_DIR}/data/tokenizer/llama3-test-tokenizer.json",
     "bos_token_id": 128000,
     "eos_token_id": 128001,
     "pad_token_id": None,
 }
-DOLMA2_TOKENIZER = {
+DOLMA2_TOKENIZER: Dict[str, Any] = {
     "filename": f"{TEST_DIR}/data/tokenizer/dolma2-test-tokenizer.json",
     "bos_token_id": None,
     "eos_token_id": 100257,
@@ -123,7 +123,9 @@ class TestTokenizer(TestCase):
 
 
 class TestTokenizerCli(TestCase):
-    def test_llama_segment_e2e(self, segment: bool = True, fast: bool = True, refresh: int = 0):
+    def test_llama_segment_e2e(
+        self, segment: bool = True, fast: bool = True, refresh: int = 0, backend: str = "hf"
+    ):
         config = {
             "destination": f"{TEST_DIR}/work/tokenizer/llama-segment",
             "documents": [
@@ -139,6 +141,7 @@ class TestTokenizerCli(TestCase):
                 "segment_before_tokenization": segment,
                 "refresh": refresh,
                 "fast": fast,
+                "backend": backend,
             },
             "debug": True,
         }
@@ -186,7 +189,9 @@ class TestTokenizerCli(TestCase):
             )
             self.assertEqual(special_tokens, 2)
 
-    def test_gpt_neo_e2e(self, segment: bool = True, fast: bool = True, refresh: int = 0):
+    def test_gpt_neo_e2e(
+        self, segment: bool = True, fast: bool = True, refresh: int = 0, backend: str = "hf"
+    ):
         config = {
             "destination": f"{TEST_DIR}/work/tokenizer/gpt-neo-segment",
             "documents": [
@@ -202,6 +207,7 @@ class TestTokenizerCli(TestCase):
                 "segment_before_tokenization": segment,
                 "refresh": refresh,
                 "fast": fast,
+                "backend": backend,
             },
             "debug": True,
         }
@@ -247,7 +253,9 @@ class TestTokenizerCli(TestCase):
             )
             self.assertEqual(special_tokens, 1)
 
-    def test_llama3_e2e(self, segment: bool = True, fast: bool = True, refresh: int = 0):
+    def test_llama3_e2e(
+        self, segment: bool = True, fast: bool = True, refresh: int = 0, backend: str = "hf"
+    ):
         config = {
             "destination": f"{TEST_DIR}/work/tokenizer/gpt-neo-segment",
             "documents": [
@@ -264,6 +272,7 @@ class TestTokenizerCli(TestCase):
                 "segment_before_tokenization": segment,
                 "refresh": refresh,
                 "fast": fast,
+                "backend": backend,
             },
             "debug": True,
         }
@@ -320,6 +329,15 @@ class TestTokenizerCli(TestCase):
 
     def test_gpt_neo_segment_e2e_refresh(self):
         self.test_gpt_neo_e2e(refresh=1)
+
+    def test_llama_segment_e2e_gigatoken(self):
+        self.test_llama_segment_e2e(backend="gt")
+
+    def test_gpt_neo_segment_e2e_gigatoken(self):
+        self.test_gpt_neo_e2e(backend="gt")
+
+    def test_llama3_e2e_gigatoken(self):
+        self.test_llama3_e2e(backend="gt")
 
 
 class TestShufflingTokenizer(TestCase):
@@ -397,9 +415,9 @@ class TestShufflingTokenizer(TestCase):
 
 
 class TestTokenizeSpecialTokens(TestCase):
-    def test_tokenize_special_tokens(self):
-        tokenizer_default = Tokenizer.from_file(**DOLMA2_TOKENIZER)
-        tokenizer_split = Tokenizer.from_file(**DOLMA2_TOKENIZER, encode_special_tokens=True)
+    def test_tokenize_special_tokens(self, backend: str = "hf"):
+        tokenizer_default = Tokenizer.from_file(**DOLMA2_TOKENIZER, backend=backend)
+        tokenizer_split = Tokenizer.from_file(**DOLMA2_TOKENIZER, encode_special_tokens=True, backend=backend)
 
         text = "This is a test document."
         tokens_default = tokenizer_default.encode(text)
@@ -424,9 +442,12 @@ class TestTokenizeSpecialTokens(TestCase):
         tokens_split = tokenizer_split.encode(text)
         self.assertEqual(tokens_default, tokens_split)
 
+    def test_tokenize_special_tokens_gigatoken(self):
+        self.test_tokenize_special_tokens(backend="gt")
+
 
 class TestBatchedTokenizeFile(TestCase):
-    def test_batched_outputs_match_single_document_encoding(self):
+    def test_batched_outputs_match_single_document_encoding(self, backend: str = "hf"):
         documents = [
             {"id": "one", "text": " first document "},
             {"id": "empty", "text": " \n "},
@@ -443,10 +464,11 @@ class TestBatchedTokenizeFile(TestCase):
                 for document in documents[2:]:
                     output.write(json.dumps(document) + "\n")
 
-            kwargs = {
+            kwargs: Dict[str, Any] = {
                 "eos_token_id": DOLMA2_TOKENIZER["eos_token_id"],
                 "pad_token_id": DOLMA2_TOKENIZER["pad_token_id"],
                 "encode_special_tokens": True,
+                "backend": backend,
             }
             outputs = list(
                 tokenize_file(
@@ -465,6 +487,10 @@ class TestBatchedTokenizeFile(TestCase):
             ]
             self.assertEqual([(output.id, output.loc, output.tokens) for output in outputs], expected)
             self.assertEqual([output.src for output in outputs], [str(path)] * len(expected))
+
+    def test_batched_outputs_match_single_document_encoding_gigatoken(self):
+        self.test_batched_outputs_match_single_document_encoding(backend="gt")
+
 
 class TestBosEosTokenAddition(TestCase):
     def setUp(self):

--- a/tests/python/test_tokenizer.py
+++ b/tests/python/test_tokenizer.py
@@ -189,9 +189,7 @@ class TestTokenizerCli(TestCase):
             )
             self.assertEqual(special_tokens, 2)
 
-    def test_gpt_neo_e2e(
-        self, segment: bool = True, fast: bool = True, refresh: int = 0, backend: str = "hf"
-    ):
+    def test_gpt_neo_e2e(self, segment: bool = True, fast: bool = True, refresh: int = 0, backend: str = "hf"):
         config = {
             "destination": f"{TEST_DIR}/work/tokenizer/gpt-neo-segment",
             "documents": [
@@ -253,9 +251,7 @@ class TestTokenizerCli(TestCase):
             )
             self.assertEqual(special_tokens, 1)
 
-    def test_llama3_e2e(
-        self, segment: bool = True, fast: bool = True, refresh: int = 0, backend: str = "hf"
-    ):
+    def test_llama3_e2e(self, segment: bool = True, fast: bool = True, refresh: int = 0, backend: str = "hf"):
         config = {
             "destination": f"{TEST_DIR}/work/tokenizer/gpt-neo-segment",
             "documents": [

--- a/tests/python/test_tokenizer.py
+++ b/tests/python/test_tokenizer.py
@@ -14,7 +14,7 @@ from tokenizers import Tokenizer as BaseTokenizer
 from typing_extensions import TypedDict
 
 from dolma.cli.__main__ import main
-from dolma.tokenizer import Tokenizer, tokenize_in_parallel
+from dolma.tokenizer import Tokenizer, tokenize_file, tokenize_in_parallel
 
 TEST_DIR = Path(__file__).parent.parent.resolve()
 
@@ -424,6 +424,47 @@ class TestTokenizeSpecialTokens(TestCase):
         tokens_split = tokenizer_split.encode(text)
         self.assertEqual(tokens_default, tokens_split)
 
+
+class TestBatchedTokenizeFile(TestCase):
+    def test_batched_outputs_match_single_document_encoding(self):
+        documents = [
+            {"id": "one", "text": " first document "},
+            {"id": "empty", "text": " \n "},
+            {"id": "two", "text": "second document"},
+            {"id": "special", "text": "contains <|endoftext|> text"},
+            {"id": "large", "text": "x" * 100},
+        ]
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "documents.jsonl.gz"
+            with smart_open.open(path, "wt") as output:
+                for document in documents[:2]:
+                    output.write(json.dumps(document) + "\n")
+                output.write("not json\n")
+                for document in documents[2:]:
+                    output.write(json.dumps(document) + "\n")
+
+            kwargs = {
+                "eos_token_id": DOLMA2_TOKENIZER["eos_token_id"],
+                "pad_token_id": DOLMA2_TOKENIZER["pad_token_id"],
+                "encode_special_tokens": True,
+            }
+            outputs = list(
+                tokenize_file(
+                    tokenizer_name_or_path=DOLMA2_TOKENIZER["filename"],
+                    path=str(path),
+                    batch_size=2,
+                    batch_max_bytes=32,
+                    **kwargs,
+                )
+            )
+
+            tokenizer = Tokenizer.from_file(DOLMA2_TOKENIZER["filename"], **kwargs)
+            expected = [
+                (document["id"], line, tokenizer.encode(document["text"].strip()))
+                for line, document in ((1, documents[0]), (4, documents[2]), (5, documents[3]), (6, documents[4]))
+            ]
+            self.assertEqual([(output.id, output.loc, output.tokens) for output in outputs], expected)
+            self.assertEqual([output.src for output in outputs], [str(path)] * len(expected))
 
 class TestBosEosTokenAddition(TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR improves the speed of the `dolma` toolkit by (a) using [gigatoken](https://github.com/marcelroed/gigatoken/) as a drop-in alternative for the huggingface backend and (b) adds document batching. For large datasets, this can give a substantial improvement in processing time; in my use cases, it improves from ~100kt/s to ~500Mt/s.

**Changes**

1. **Tokenizer backend (`gt` support):** `Tokenizer` now wraps both `gigatoken.Tokenizer` and huggingface's `tokenizers.Tokenizer`. Selectable with a new `--tokenizer.backend` flag. When `--tokenizer.fast` is `False`, this has no effect.
2. **Batching:** `tokenize_file` now accumulates documents into batches (bounded by a new `--tokenizer.batch_size / --tokenizer.batch_max_bytes` CLI config, defaulting to 64 docs / 8 MiB) and calls `encode_batch` instead of encoding per-document. Per-record error handling is preserved, so if a batch fails to encode, it falls back to encoding records individually so one bad document doesn't drop its neighbors.
3. **Dependency:** added `gigatoken>=0.10.0,<0.11.0` to `pyproject.toml`. Pinned with an upper bound since the wrapper relies on gigatoken's private `_hf_config()` method, and the package is still young/moving fast.

**Testing**

On dolma's test data, using the `gt` backend over the `hf` backend yields a ~10x speedup; when adding source batching, this extends to a ~18x speedup:


Mode | hf backend | gt backend | Speedup
-- | -- | -- | --
singleton (`encode` per doc) | 864,291 tok/s (107.3s) | 8,434,734 tok/s (11.0s) | ~9.8x
batched (`encode_batch`, size 64) | 2,818,331 tok/s (32.9s) | 50,165,011 tok/s (1.8s) | ~17.8x